### PR TITLE
Fix enum case parsing

### DIFF
--- a/anthropic/src/types.rs
+++ b/anthropic/src/types.rs
@@ -32,6 +32,7 @@ pub struct CompleteResponse {
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum StopReason {
     MaxTokens,
     StopSequence,


### PR DESCRIPTION
Fixes the following error:

```
failed to deserialize api response: unknown variant `stop_sequence`, expected `MaxTokens` or `StopSequence` at line 1 column 297
```