### PR TITLE
Implement streaming

### DIFF
--- a/anthropic/Cargo.toml
+++ b/anthropic/Cargo.toml
@@ -31,8 +31,10 @@ serde = "1.0.163"
 serde_derive = "1.0.163"
 serde_json = "1.0.96"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1.14"
 thiserror = "1.0.40"
 rustc_version = "0.4.0"
+reqwest-eventsource = "0.4.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/anthropic/README.md
+++ b/anthropic/README.md
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let complete_request = CompleteRequestBuilder::default()
         .prompt(format!("{HUMAN_PROMPT}How many toes do dogs have?{AI_PROMPT}"))
-        .model("claude-v1".to_string())
+        .model("claude-instant-1".to_string())
         .stream_response(false)
         .stop_sequences(vec![HUMAN_PROMPT.to_string()])
         .build()?;

--- a/anthropic/src/error.rs
+++ b/anthropic/src/error.rs
@@ -13,6 +13,9 @@ pub enum AnthropicError {
     /// Error when a response cannot be deserialized into a Rust type
     #[error("failed to deserialize api response: {0}")]
     JSONDeserialize(serde_json::Error),
+    /// Error on SSE streaming
+    #[error("stream failed: {0}")]
+    StreamError(String),
     /// Error from client side validation
     /// or when builder fails to build request before making API call
     #[error("invalid args: {0}")]

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -21,8 +21,8 @@
 //!
 //! let complete_request = CompleteRequestBuilder::default()
 //!     .prompt(format!("{HUMAN_PROMPT}How many toes do dogs have?{AI_PROMPT}"))
-//!     .model("claude-v1".to_string())
-//!     .stream_response(false)
+//!     .model("claude-instant-1".to_string())
+//!     .stream(false)
 //!     .stop_sequences(vec![HUMAN_PROMPT.to_string()])
 //!     .build()?;
 //!
@@ -59,9 +59,15 @@ pub const DEFAULT_MODEL: &str = "claude-v1";
 /// Default v1 API base url.
 pub const DEFAULT_API_BASE: &str = "https://api.anthropic.com";
 /// Auth header key.
-pub const AUTHORIZATION_HEADER_KEY: &str = "x-api-key";
+const AUTHORIZATION_HEADER_KEY: &str = "x-api-key";
 /// Client id header key.
-pub const CLIENT_ID_HEADER_KEY: &str = "Client";
+const CLIENT_ID_HEADER_KEY: &str = "Client";
+/// API version header key.
+/// Ref: https://docs.anthropic.com/claude/reference/versioning
+const API_VERSION_HEADER_KEY: &str = "anthropic-version";
+
+/// Ref: https://docs.anthropic.com/claude/reference/versioning
+const API_VERSION: &str = "2023-06-01";
 
 /// Get the client id.
 pub fn client_id() -> String {

--- a/anthropic/src/main.rs
+++ b/anthropic/src/main.rs
@@ -20,8 +20,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let complete_request = CompleteRequestBuilder::default()
         .prompt(format!("{HUMAN_PROMPT}How many toes do dogs have?{AI_PROMPT}"))
-        .model("claude-v1".to_string())
-        .stream_response(false)
+        .model("claude-instant-1".to_string())
+        .stream(false)
         .stop_sequences(vec![HUMAN_PROMPT.to_string()])
         .build()?;
 

--- a/anthropic/src/types.rs
+++ b/anthropic/src/types.rs
@@ -1,6 +1,9 @@
 //! Module for types used in the API.
+use std::pin::Pin;
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use tokio_stream::Stream;
 
 use crate::error::AnthropicError;
 use crate::DEFAULT_MODEL;
@@ -22,14 +25,17 @@ pub struct CompleteRequest {
     pub stop_sequences: Option<Vec<String>>,
     /// Whether to incrementally stream the response.
     #[builder(default = "false")]
-    pub stream_response: bool,
+    pub stream: bool,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct CompleteResponse {
     pub completion: String,
-    pub stop_reason: StopReason,
+    pub stop_reason: Option<StopReason>,
 }
+
+/// Parsed server side events stream until a [StopReason::StopSequence] is received from server.
+pub type CompleteResponseStream = Pin<Box<dyn Stream<Item = Result<CompleteResponse, AnthropicError>> + Send>>;
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "basic-completion",
+    "streaming-completion",
 ]
 resolver = "2"

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,3 +19,4 @@ cargo run
 ## List of examples
 
 - [basic-completion](basic-completion): A basic example of completion.
+- [streaming-completion](streaming-completion): An example of streaming the completion response.

--- a/examples/streaming-completion/Cargo.toml
+++ b/examples/streaming-completion/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "streaming-completion"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anthropic = {path = "../../anthropic"}
+tokio = { version = "1.25.0", features = ["full"] }
+tokio-stream = "0.1.14"
+env_logger = "0.10.0"
+log = "0.4.17"
+dotenv = "0.15.0"
+

--- a/examples/streaming-completion/src/main.rs
+++ b/examples/streaming-completion/src/main.rs
@@ -40,10 +40,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 print!("{}", response.completion);
                 std::io::stdout().flush().unwrap();
-            },
+            }
             Err(e) => {
                 println!("\n{e}\n")
-            },
+            }
         }
     }
 


### PR DESCRIPTION
This PR implements the missing streaming completion feature, largely based on the `async-openai` crate's streaming implementation.

Some other changes I had to make in this PR:

- ⚠️ breaking change: rename `CompleteRequest`'s `stream_response` field to `stream`. This is how the API request parameter is named.
- Replace the model `claude-v1` in the examples as it's not a valid model ID ([ref](https://docs.anthropic.com/claude/reference/selecting-a-model))
- ⚠️ breaking change: make `CompleteResponse.stop_reason` `Option<T>` because in the streaming case it can be null.