### PR TITLE
Handle no Rust version info at runtime gracefully

### DIFF
--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -72,7 +72,10 @@ const API_VERSION: &str = "2023-06-01";
 /// Get the client id.
 pub fn client_id() -> String {
     // Get the Rust version used to build SDK at compile time.
-    let rust_version = version().unwrap();
+    let rust_version = match version() {
+        Ok(v) => v.to_string(),
+        Err(_) => "unknown".to_string(),
+    };
     let crate_name = env!("CARGO_PKG_NAME");
     let crate_version = env!("CARGO_PKG_VERSION");
     format!("rustv{rust_version}/{crate_name}/{crate_version}")


### PR DESCRIPTION
I'm containerizing my Rust binary and noticed that this crate panics when the final container has no `rustc` available. Turns out, the `rust_version` crate is used for generating the client ID at runtime, without handling its error gracefully.

This PR adds graceful error handling when the version information is not available at runtime.