### PR TITLE
add `PauseTurn` and `Refusal` variants to `StopReason`

### DIFF
--- a/anthropic/src/types.rs
+++ b/anthropic/src/types.rs
@@ -225,6 +225,8 @@ pub enum StopReason {
     MaxTokens,
     StopSequence,
     ToolUse,
+    PauseTurn,
+    Refusal,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
This PR adds two missing `StopReason` variants. The relevant model in the docs is [here](https://platform.claude.com/docs/en/api/messages#stop_reason).