### PR TITLE
feat(types): cache_control, extended thinking, document blocks, helpers + 30 unit tests

### DIFF
--- a/anthropic/Cargo.toml
+++ b/anthropic/Cargo.toml
@@ -30,3 +30,4 @@ tokio-stream = "0.1"
 
 [dev-dependencies]
 dotenvy = "0.15"
+wiremock = "0.6"

--- a/anthropic/README.md
+++ b/anthropic/README.md
@@ -93,95 +93,208 @@ MessagesResponse {
 ### 1. Send one typed message
 
 ```rust
-use anthropic::types::{ContentBlock, Message, MessagesRequestBuilder, Role};
+use anthropic::types::{Message, MessagesRequestBuilder};
 use anthropic::Client;
 
 let client = Client::from_env()?;
 let request = MessagesRequestBuilder::new(
     "claude-3-5-sonnet-20240620",
-    vec![Message {
-        role: Role::User,
-        content: vec![ContentBlock::text("Summarize this diff in one sentence.")],
-    }],
+    vec![Message::user("Summarize this diff in one sentence.")],
     256,
 )
 .temperature(0.2)
 .build()?;
 
 let response = client.messages(request).await?;
+println!("{}", response.text());
 ```
 
-- `model` selects the Anthropic model.
-- `max_tokens` caps output length.
-- `temperature(0.2)` keeps output tighter and less varied.
+- `Message::user` / `Message::assistant` wrap a single text block — no enum literals required.
+- `MessagesResponse::text()`, `first_text()`, and `tool_uses()` pull structured
+  data back out without matching on `ContentBlock` by hand.
+- `temperature(0.2)` keeps output tighter and less varied; the builder also
+  validates non-empty `model` / `messages` and non-zero `max_tokens`.
 
-### 2. Stream text as it arrives
+### 2. Stream text and materialize the final response
 
 ```rust
-use anthropic::types::{ContentBlock, ContentBlockDelta, Message, MessagesRequestBuilder, MessagesStreamEvent, Role};
+use anthropic::stream::StreamAccumulator;
+use anthropic::types::{ContentBlockDelta, Message, MessagesRequestBuilder, MessagesStreamEvent};
 use anthropic::Client;
 use tokio_stream::StreamExt;
 
 let client = Client::from_env()?;
 let request = MessagesRequestBuilder::new(
     "claude-3-5-sonnet-20240620",
-    vec![Message {
-        role: Role::User,
-        content: vec![ContentBlock::text("Stream a short release note.")],
-    }],
+    vec![Message::user("Stream a short release note.")],
     128,
 )
 .build()?;
 
 let mut stream = client.messages_stream(request).await?;
+let mut accumulator = StreamAccumulator::new();
 
 while let Some(event) = stream.next().await {
-    if let Ok(MessagesStreamEvent::ContentBlockDelta {
+    let event = event?;
+    if let MessagesStreamEvent::ContentBlockDelta {
         delta: ContentBlockDelta::TextDelta { text },
         ..
-    }) = event
-    {
+    } = &event {
         print!("{text}");
     }
+    accumulator.push(event)?;
 }
+
+let response = accumulator.finish()?;
 ```
 
-- `messages_stream()` forces `stream=true` and yields typed SSE events.
-- Match `ContentBlockDelta::TextDelta` when you only care about visible text.
-- The `examples/streaming-messages` helper rebuilds the final assistant message from start, delta, and stop events.
+- `StreamAccumulator` folds every `MessagesStreamEvent` into a
+  `MessagesResponse`, handling text, tool-use `input_json_delta` chunks,
+  extended-thinking `thinking_delta` / `signature_delta`, and usage /
+  stop-reason updates.
+- Prefer `anthropic::stream::collect(stream).await` when you just want the
+  final response without any per-event processing.
 
-### 3. Ask for tool input instead of plain text
+### 3. Drive a full tool-use loop with one helper
 
 ```rust
-use anthropic::types::{ContentBlock, Message, MessagesRequestBuilder, Role, Tool, ToolChoice};
+use anthropic::tool_loop::{run_tool_loop, ToolLoopConfig, ToolOutput};
+use anthropic::types::{Message, MessagesRequestBuilder, Tool, ToolChoice};
+use anthropic::Client;
 use serde_json::json;
+
+let client = Client::from_env()?;
+let request = MessagesRequestBuilder::new(
+    "claude-3-5-sonnet-20240620",
+    vec![Message::user("What's the weather in Paris?")],
+    512,
+)
+.tools(vec![Tool::new(
+    "get_weather",
+    "Fetch current weather for a city",
+    json!({
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+    }),
+)])
+.tool_choice(ToolChoice::Auto)
+.build()?;
+
+let response = run_tool_loop(
+    &client,
+    request,
+    |name, input| async move {
+        assert_eq!(name, "get_weather");
+        let city = input["city"].as_str().unwrap_or("");
+        Ok(ToolOutput::ok(format!("{city}: 22C and sunny")))
+    },
+    ToolLoopConfig::default(),
+)
+.await?;
+
+println!("{}", response.text());
+```
+
+- `run_tool_loop` handles the entire call-execute-reply cycle — it clones
+  the original request each iteration (keeping `tools` / `tool_choice` /
+  `system` intact), collects every `tool_use` block in parallel, runs your
+  executor, appends `tool_result` blocks, and stops once the model returns
+  a tool-free response or `max_iterations` is hit.
+- Return `ToolOutput::error("...")` to surface a tool-level failure to the
+  model; return `Err(AnthropicError)` to abort the loop instead.
+
+### 4. Prompt caching, extended thinking, and image / document blocks
+
+```rust
+use anthropic::types::{CacheControl, ContentBlock, Message, MessagesRequestBuilder, Role, ServiceTier, ThinkingConfig};
 
 let request = MessagesRequestBuilder::new(
     "claude-3-5-sonnet-20240620",
-    vec![Message {
-        role: Role::User,
-        content: vec![ContentBlock::text("What's the weather in Paris?")],
-    }],
-    256,
+    vec![
+        Message::new(
+            Role::User,
+            vec![
+                ContentBlock::image_url("https://example.com/chart.png"),
+                ContentBlock::document_url("https://example.com/handbook.pdf"),
+                ContentBlock::text("Summarize both attachments."),
+            ],
+        ),
+    ],
+    1024,
 )
-.tools(vec![Tool {
-    name: "get_weather".into(),
-    description: "Fetch current weather for a city.".into(),
-    input_schema: json!({
-        "type": "object",
-        "properties": {
-            "city": { "type": "string" }
-        },
-        "required": ["city"]
-    }),
-}])
-.tool_choice(ToolChoice::Any)
+.system("You are a careful analyst.")
+.thinking(ThinkingConfig::enabled(2048))
+.service_tier(ServiceTier::Auto)
+.tools(vec![]) // add tool schemas as needed
 .build()?;
+
+// Tag any cacheable block or tool with a CacheControl marker:
+let cached_prompt = ContentBlock::text("...long system context...")
+    .with_cache_control(CacheControl::ephemeral());
 ```
 
-- `tools(...)` registers callable tool schemas.
-- `tool_choice(ToolChoice::Any)` tells the model it may call a tool.
-- Tool results round-trip through `ContentBlock::ToolUse` and `ContentBlock::ToolResult`.
+- `CacheControl::ephemeral()` / `::ephemeral_ttl("1h")` attach a cache
+  marker to any `Text` / `Image` / `Document` / `ToolUse` / `ToolResult`
+  block or tool definition.
+- `ContentBlock` constructors cover base64 / URL images, base64 / URL /
+  inline text documents, tool-use + tool-result (ok and error), thinking
+  (with optional signature), and plain text.
+- `ThinkingConfig::enabled(budget)` turns on extended thinking;
+  `ServiceTier::StandardOnly` opts out of priority routing.
+
+### 5. count_tokens, list_models, get_model
+
+```rust
+use anthropic::count_tokens::CountTokensRequestBuilder;
+use anthropic::models::ListModelsParams;
+use anthropic::types::Message;
+
+let count = client
+    .count_tokens(
+        CountTokensRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("hi")]).build()?,
+    )
+    .await?;
+println!("this request would cost {} input tokens", count.input_tokens);
+
+let models = client.list_models(&ListModelsParams::new().limit(20)).await?;
+for m in &models.data {
+    println!("{} - {}", m.id, m.display_name);
+}
+let detail = client.get_model("claude-3-5-sonnet-20240620").await?;
+```
+
+### 6. Message Batches
+
+```rust
+use anthropic::batches::{BatchRequest, CreateBatchRequest, ListBatchesParams};
+use anthropic::types::{Message, MessagesRequestBuilder};
+
+let batch = client
+    .create_batch(CreateBatchRequest::new(vec![
+        BatchRequest::new(
+            "req_1",
+            MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("hi")], 64).build()?,
+        ),
+        BatchRequest::new(
+            "req_2",
+            MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("bye")], 64).build()?,
+        ),
+    ]))
+    .await?;
+
+// Poll until the batch finishes...
+let batch = client.get_batch(&batch.id).await?;
+if batch.is_complete() {
+    for item in client.get_batch_results(&batch.id).await? {
+        println!("{}: {:?}", item.custom_id, item.result);
+    }
+}
+
+// Or page through every batch on the workspace:
+let _list = client.list_batches(&ListBatchesParams::new().limit(10)).await?;
+// ...cancel_batch / delete_batch round out the CRUD surface.
+```
 
 ## Configuration
 
@@ -199,10 +312,18 @@ let request = MessagesRequestBuilder::new(
 
 | Call | Returns | Notes |
 | --- | --- | --- |
-| `Client::new(api_key)` | `Result<Client, AnthropicError>` | Manual setup when you do not want env-based config. |
+| `Client::new(api_key)` / `Client::builder()` | `Result<Client, AnthropicError>` | Manual setup when you do not want env-based config. |
 | `Client::from_env()` | `Result<Client, AnthropicError>` | Reads the environment variables above. |
 | `client.messages(request)` | `Result<MessagesResponse, AnthropicError>` | Rejects `stream=true` requests. |
 | `client.messages_stream(request)` | `Result<MessagesResponseStream, AnthropicError>` | Opens an SSE stream and yields typed events. |
+| `client.count_tokens(request)` | `Result<CountTokensResponse, AnthropicError>` | `POST /v1/messages/count_tokens`. |
+| `client.list_models(&params)` / `client.get_model(id)` | `Result<ModelList / Model, AnthropicError>` | `GET /v1/models` with pagination. |
+| `client.create_batch(request)` | `Result<MessageBatch, AnthropicError>` | `POST /v1/messages/batches` with local non-empty validation. |
+| `client.list_batches(&params)` / `client.get_batch(id)` | `Result<MessageBatchList / MessageBatch, AnthropicError>` | List and poll batches. |
+| `client.cancel_batch(id)` / `client.delete_batch(id)` | `Result<.., AnthropicError>` | Batch lifecycle management. |
+| `client.get_batch_results(id)` | `Result<Vec<BatchResultItem>, AnthropicError>` | Download + parse the JSONL results file. |
+| `StreamAccumulator` / `anthropic::stream::collect` | `Result<MessagesResponse, AnthropicError>` | Folds a live SSE stream into a full response. |
+| `run_tool_loop(&client, request, executor, config)` | `Result<MessagesResponse, AnthropicError>` | Agentic call/execute/reply loop with iteration budget. |
 | `ClientBuilder::backoff(...)` | `ClientBuilder` | Customizes retry behavior for cloneable requests. |
 
 ## Deployment / Integration

--- a/anthropic/src/batches.rs
+++ b/anthropic/src/batches.rs
@@ -1,0 +1,330 @@
+//! Types for the Message Batches API (`/v1/messages/batches`).
+//!
+//! Message batches let callers submit many Messages requests in a single
+//! operation and poll for results asynchronously. Each request in the batch is
+//! identified by a `custom_id` that the caller chooses.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AnthropicError;
+use crate::types::{MessagesRequest, MessagesResponse};
+
+/// Individual request entry submitted as part of a batch.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct BatchRequest {
+    pub custom_id: String,
+    pub params: MessagesRequest,
+}
+
+impl BatchRequest {
+    pub fn new(custom_id: impl Into<String>, params: MessagesRequest) -> Self {
+        Self { custom_id: custom_id.into(), params }
+    }
+}
+
+/// Payload for `POST /v1/messages/batches`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct CreateBatchRequest {
+    pub requests: Vec<BatchRequest>,
+}
+
+impl CreateBatchRequest {
+    pub fn new(requests: Vec<BatchRequest>) -> Self {
+        Self { requests }
+    }
+
+    /// Validate that a batch has at least one request before sending.
+    pub fn validate(&self) -> Result<(), AnthropicError> {
+        if self.requests.is_empty() {
+            return Err(AnthropicError::InvalidRequest("batch must contain at least one request".into()));
+        }
+        Ok(())
+    }
+}
+
+/// Processing state of a batch as a whole.
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchProcessingStatus {
+    InProgress,
+    Canceling,
+    Ended,
+}
+
+/// Per-status request counts that the API returns alongside every batch.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+pub struct BatchRequestCounts {
+    #[serde(default)]
+    pub processing: u32,
+    #[serde(default)]
+    pub succeeded: u32,
+    #[serde(default)]
+    pub errored: u32,
+    #[serde(default)]
+    pub canceled: u32,
+    #[serde(default)]
+    pub expired: u32,
+}
+
+/// Batch metadata returned by `POST /v1/messages/batches` and the get/list
+/// endpoints.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct MessageBatch {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub batch_type: String,
+    pub processing_status: BatchProcessingStatus,
+    pub request_counts: BatchRequestCounts,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    pub created_at: String,
+    pub expires_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cancel_initiated_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub results_url: Option<String>,
+}
+
+impl MessageBatch {
+    /// True when the batch has stopped processing (ended, canceled, or expired).
+    pub fn is_complete(&self) -> bool {
+        matches!(self.processing_status, BatchProcessingStatus::Ended)
+    }
+}
+
+/// Paginated list of batches returned by `GET /v1/messages/batches`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct MessageBatchList {
+    pub data: Vec<MessageBatch>,
+    #[serde(default)]
+    pub has_more: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+}
+
+/// Pagination parameters for listing batches.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListBatchesParams {
+    pub before_id: Option<String>,
+    pub after_id: Option<String>,
+    pub limit: Option<u32>,
+}
+
+impl ListBatchesParams {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub(crate) fn as_query(&self) -> Vec<(&'static str, String)> {
+        let mut out = Vec::new();
+        if let Some(before) = &self.before_id {
+            out.push(("before_id", before.clone()));
+        }
+        if let Some(after) = &self.after_id {
+            out.push(("after_id", after.clone()));
+        }
+        if let Some(limit) = self.limit {
+            out.push(("limit", limit.to_string()));
+        }
+        out
+    }
+}
+
+/// Outcome of a single request inside a batch result payload.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum BatchRequestResult {
+    Succeeded { message: MessagesResponse },
+    Errored { error: serde_json::Value },
+    Canceled,
+    Expired,
+}
+
+/// Individual line item returned by the results endpoint.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct BatchResultItem {
+    pub custom_id: String,
+    pub result: BatchRequestResult,
+}
+
+/// Parse a JSON-Lines payload (one `BatchResultItem` per line) into a vector.
+///
+/// Blank lines are ignored.
+pub fn parse_results_jsonl(body: &str) -> Result<Vec<BatchResultItem>, AnthropicError> {
+    let mut out = Vec::new();
+    for (idx, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let item: BatchResultItem = serde_json::from_str(trimmed).map_err(|e| {
+            AnthropicError::InvalidRequest(format!("failed to parse batch result line {}: {}", idx + 1, e))
+        })?;
+        out.push(item);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Message, MessagesRequestBuilder};
+    use serde_json::json;
+
+    fn sample_request() -> MessagesRequest {
+        MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 128).build().unwrap()
+    }
+
+    #[test]
+    fn create_batch_request_validates_non_empty() {
+        let err = CreateBatchRequest::new(vec![]).validate().unwrap_err();
+        assert!(format!("{err}").contains("at least one"));
+
+        CreateBatchRequest::new(vec![BatchRequest::new("a", sample_request())]).validate().unwrap();
+    }
+
+    #[test]
+    fn message_batch_deserializes() {
+        let batch: MessageBatch = serde_json::from_value(json!({
+            "id": "msgbatch_01",
+            "type": "message_batch",
+            "processing_status": "in_progress",
+            "request_counts": {
+                "processing": 2,
+                "succeeded": 1,
+                "errored": 0,
+                "canceled": 0,
+                "expired": 0
+            },
+            "ended_at": null,
+            "created_at": "2024-10-01T00:00:00Z",
+            "expires_at": "2024-10-02T00:00:00Z",
+            "archived_at": null,
+            "cancel_initiated_at": null,
+            "results_url": null
+        }))
+        .unwrap();
+        assert_eq!(batch.id, "msgbatch_01");
+        assert_eq!(batch.processing_status, BatchProcessingStatus::InProgress);
+        assert_eq!(batch.request_counts.processing, 2);
+        assert_eq!(batch.request_counts.succeeded, 1);
+        assert!(!batch.is_complete());
+    }
+
+    #[test]
+    fn message_batch_is_complete_when_ended() {
+        let batch: MessageBatch = serde_json::from_value(json!({
+            "id": "msgbatch_01",
+            "type": "message_batch",
+            "processing_status": "ended",
+            "request_counts": {"processing": 0, "succeeded": 2, "errored": 0, "canceled": 0, "expired": 0},
+            "created_at": "2024-10-01T00:00:00Z",
+            "expires_at": "2024-10-02T00:00:00Z",
+            "results_url": "https://api.anthropic.com/v1/messages/batches/msgbatch_01/results"
+        }))
+        .unwrap();
+        assert!(batch.is_complete());
+        assert_eq!(
+            batch.results_url.as_deref(),
+            Some("https://api.anthropic.com/v1/messages/batches/msgbatch_01/results")
+        );
+    }
+
+    #[test]
+    fn list_batches_params_builds_query() {
+        let params = ListBatchesParams::new().limit(5).before_id("b1");
+        assert_eq!(params.as_query(), vec![("before_id", "b1".to_string()), ("limit", "5".to_string())]);
+    }
+
+    #[test]
+    fn batch_result_succeeded_roundtrip() {
+        let body = json!({
+            "custom_id": "req_1",
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                    "model": "claude",
+                    "stop_reason": "end_turn",
+                    "stop_sequence": null,
+                    "usage": {"input_tokens": 3, "output_tokens": 1}
+                }
+            }
+        });
+        let item: BatchResultItem = serde_json::from_value(body).unwrap();
+        assert_eq!(item.custom_id, "req_1");
+        match item.result {
+            BatchRequestResult::Succeeded { message } => {
+                assert_eq!(message.text(), "done");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn batch_result_errored_and_canceled_roundtrip() {
+        let errored: BatchResultItem = serde_json::from_value(json!({
+            "custom_id": "req_2",
+            "result": {"type": "errored", "error": {"type": "invalid_request_error", "message": "bad"}}
+        }))
+        .unwrap();
+        matches!(errored.result, BatchRequestResult::Errored { .. });
+
+        let canceled: BatchResultItem = serde_json::from_value(json!({
+            "custom_id": "req_3",
+            "result": {"type": "canceled"}
+        }))
+        .unwrap();
+        assert!(matches!(canceled.result, BatchRequestResult::Canceled));
+    }
+
+    #[test]
+    fn parse_jsonl_handles_multiple_lines_and_blanks() {
+        let body = r#"{"custom_id":"a","result":{"type":"canceled"}}
+
+{"custom_id":"b","result":{"type":"expired"}}
+"#;
+        let items = parse_results_jsonl(body).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].custom_id, "a");
+        assert!(matches!(items[0].result, BatchRequestResult::Canceled));
+        assert_eq!(items[1].custom_id, "b");
+        assert!(matches!(items[1].result, BatchRequestResult::Expired));
+    }
+
+    #[test]
+    fn parse_jsonl_reports_line_number_on_error() {
+        let body = "{\"custom_id\":\"a\",\"result\":{\"type\":\"canceled\"}}\nnot json";
+        let err = parse_results_jsonl(body).unwrap_err();
+        assert!(format!("{err}").contains("line 2"));
+    }
+
+    #[test]
+    fn batch_request_counts_default_zero() {
+        let counts = BatchRequestCounts::default();
+        assert_eq!(counts.processing, 0);
+        assert_eq!(counts.succeeded, 0);
+    }
+}

--- a/anthropic/src/client.rs
+++ b/anthropic/src/client.rs
@@ -9,6 +9,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio_stream::Stream;
 
+use crate::batches::{
+    parse_results_jsonl, BatchResultItem, CreateBatchRequest, ListBatchesParams, MessageBatch, MessageBatchList,
+};
 use crate::count_tokens::{CountTokensRequest, CountTokensResponse};
 use crate::error::{AnthropicError, ErrorResponse};
 use crate::models::{ListModelsParams, Model, ModelList};
@@ -189,6 +192,44 @@ impl Client {
         self.get::<Model>(&path, &[]).await
     }
 
+    /// `POST /v1/messages/batches` — submit a new batch of Messages requests.
+    pub async fn create_batch(&self, request: CreateBatchRequest) -> Result<MessageBatch, AnthropicError> {
+        request.validate()?;
+        self.post("/v1/messages/batches", &request).await
+    }
+
+    /// `GET /v1/messages/batches` — list batches submitted by this workspace.
+    pub async fn list_batches(&self, params: &ListBatchesParams) -> Result<MessageBatchList, AnthropicError> {
+        self.get("/v1/messages/batches", &params.as_query()).await
+    }
+
+    /// `GET /v1/messages/batches/{id}` — fetch current metadata for a batch.
+    pub async fn get_batch(&self, batch_id: &str) -> Result<MessageBatch, AnthropicError> {
+        let path = format!("/v1/messages/batches/{}", batch_id);
+        self.get::<MessageBatch>(&path, &[]).await
+    }
+
+    /// `POST /v1/messages/batches/{id}/cancel` — request cancellation of a
+    /// batch. Already-completed requests remain available in the results.
+    pub async fn cancel_batch(&self, batch_id: &str) -> Result<MessageBatch, AnthropicError> {
+        let path = format!("/v1/messages/batches/{}/cancel", batch_id);
+        self.post_empty::<MessageBatch>(&path).await
+    }
+
+    /// `DELETE /v1/messages/batches/{id}` — permanently delete a batch.
+    pub async fn delete_batch(&self, batch_id: &str) -> Result<serde_json::Value, AnthropicError> {
+        let path = format!("/v1/messages/batches/{}", batch_id);
+        self.delete::<serde_json::Value>(&path).await
+    }
+
+    /// `GET /v1/messages/batches/{id}/results` — download and parse the
+    /// JSON-Lines results file for a completed batch.
+    pub async fn get_batch_results(&self, batch_id: &str) -> Result<Vec<BatchResultItem>, AnthropicError> {
+        let path = format!("/v1/messages/batches/{}/results", batch_id);
+        let body = self.get_raw(&path).await?;
+        parse_results_jsonl(&body)
+    }
+
     fn headers(&self) -> Result<HeaderMap, AnthropicError> {
         let mut headers = HeaderMap::new();
         headers.insert(API_KEY_HEADER, HeaderValue::from_str(&self.api_key)?);
@@ -220,6 +261,27 @@ impl Client {
         let request =
             self.http_client.get(format!("{}{path}", self.api_base)).headers(self.headers()?).query(query).build()?;
 
+        self.execute(request).await
+    }
+
+    async fn get_raw(&self, path: &str) -> Result<String, AnthropicError> {
+        let request = self.http_client.get(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
+        self.execute_raw(request).await
+    }
+
+    async fn post_empty<O>(&self, path: &str) -> Result<O, AnthropicError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = self.http_client.post(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
+        self.execute(request).await
+    }
+
+    async fn delete<O>(&self, path: &str) -> Result<O, AnthropicError>
+    where
+        O: DeserializeOwned,
+    {
+        let request = self.http_client.delete(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
         self.execute(request).await
     }
 
@@ -286,6 +348,54 @@ impl Client {
             None => {
                 let response = client.execute(request).await?;
                 process_response(response).await
+            }
+        }
+    }
+
+    async fn execute_raw(&self, request: reqwest::Request) -> Result<String, AnthropicError> {
+        let client = self.http_client.clone();
+
+        match request.try_clone() {
+            Some(request) => {
+                backoff::future::retry(self.backoff.clone(), || {
+                    let request = request.try_clone().ok_or_else(|| {
+                        backoff::Error::Permanent(AnthropicError::InvalidRequest("request could not be cloned".into()))
+                    });
+                    let client = client.clone();
+                    async move {
+                        let request = request?;
+                        let response = client
+                            .execute(request)
+                            .await
+                            .map_err(AnthropicError::Http)
+                            .map_err(backoff::Error::Permanent)?;
+
+                        let status = response.status();
+                        let bytes =
+                            response.bytes().await.map_err(AnthropicError::Http).map_err(backoff::Error::Permanent)?;
+
+                        if !status.is_success() {
+                            let error = parse_error(status.as_u16(), bytes.as_ref());
+                            if status.as_u16() == 429 {
+                                return Err(backoff::Error::Transient { err: error, retry_after: None });
+                            }
+                            return Err(backoff::Error::Permanent(error));
+                        }
+
+                        let body = String::from_utf8_lossy(bytes.as_ref()).into_owned();
+                        Ok(body)
+                    }
+                })
+                .await
+            }
+            None => {
+                let response = client.execute(request).await?;
+                let status = response.status();
+                let bytes = response.bytes().await?;
+                if !status.is_success() {
+                    return Err(parse_error(status.as_u16(), bytes.as_ref()));
+                }
+                Ok(String::from_utf8_lossy(bytes.as_ref()).into_owned())
             }
         }
     }

--- a/anthropic/src/client.rs
+++ b/anthropic/src/client.rs
@@ -9,7 +9,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio_stream::Stream;
 
+use crate::count_tokens::{CountTokensRequest, CountTokensResponse};
 use crate::error::{AnthropicError, ErrorResponse};
+use crate::models::{ListModelsParams, Model, ModelList};
 use crate::types::{MessagesRequest, MessagesResponse, MessagesStreamEvent};
 
 const DEFAULT_API_BASE: &str = "https://api.anthropic.com";
@@ -106,6 +108,11 @@ impl Client {
         ClientBuilder::new().api_key(api_key).build()
     }
 
+    /// Shortcut for [`ClientBuilder::new`].
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
+
     pub fn from_env() -> Result<Self, AnthropicError> {
         let api_key = std::env::var("ANTHROPIC_API_KEY")
             .map_err(|_| AnthropicError::MissingEnvironment("ANTHROPIC_API_KEY".into()))?;
@@ -165,6 +172,23 @@ impl Client {
         self.post_stream("/v1/messages", &request).await
     }
 
+    /// `POST /v1/messages/count_tokens` — compute the input-token cost of a
+    /// Messages request without actually generating a response.
+    pub async fn count_tokens(&self, request: CountTokensRequest) -> Result<CountTokensResponse, AnthropicError> {
+        self.post("/v1/messages/count_tokens", &request).await
+    }
+
+    /// `GET /v1/models` — list every model available to the authenticated key.
+    pub async fn list_models(&self, params: &ListModelsParams) -> Result<ModelList, AnthropicError> {
+        self.get("/v1/models", &params.as_query()).await
+    }
+
+    /// `GET /v1/models/{model_id}` — fetch metadata about a single model.
+    pub async fn get_model(&self, model_id: &str) -> Result<Model, AnthropicError> {
+        let path = format!("/v1/models/{}", model_id);
+        self.get::<Model>(&path, &[]).await
+    }
+
     fn headers(&self) -> Result<HeaderMap, AnthropicError> {
         let mut headers = HeaderMap::new();
         headers.insert(API_KEY_HEADER, HeaderValue::from_str(&self.api_key)?);
@@ -185,6 +209,16 @@ impl Client {
     {
         let request =
             self.http_client.post(format!("{}{path}", self.api_base)).headers(self.headers()?).json(request).build()?;
+
+        self.execute(request).await
+    }
+
+    async fn get<O>(&self, path: &str, query: &[(&str, String)]) -> Result<O, AnthropicError>
+    where
+        O: DeserializeOwned,
+    {
+        let request =
+            self.http_client.get(format!("{}{path}", self.api_base)).headers(self.headers()?).query(query).build()?;
 
         self.execute(request).await
     }

--- a/anthropic/src/count_tokens.rs
+++ b/anthropic/src/count_tokens.rs
@@ -1,0 +1,159 @@
+//! Types for the `/v1/messages/count_tokens` endpoint.
+//!
+//! Lets callers pre-compute the input-token cost of a Messages request without
+//! actually generating a response.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AnthropicError;
+use crate::types::{Message, MessagesRequest, SystemPrompt, ThinkingConfig, Tool, ToolChoice};
+
+/// Request payload for `POST /v1/messages/count_tokens`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct CountTokensRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<SystemPrompt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+}
+
+impl CountTokensRequest {
+    /// Build a count-tokens request from an existing [`MessagesRequest`].
+    ///
+    /// Fields that don't affect token counting (max_tokens, temperature, etc.)
+    /// are dropped.
+    pub fn from_messages_request(request: &MessagesRequest) -> Self {
+        Self {
+            model: request.model.clone(),
+            messages: request.messages.clone(),
+            system: request.system.clone(),
+            tools: request.tools.clone(),
+            tool_choice: request.tool_choice.clone(),
+            thinking: request.thinking.clone(),
+        }
+    }
+}
+
+/// Builder for [`CountTokensRequest`].
+#[derive(Debug, Default)]
+pub struct CountTokensRequestBuilder {
+    model: Option<String>,
+    messages: Option<Vec<Message>>,
+    system: Option<SystemPrompt>,
+    tools: Option<Vec<Tool>>,
+    tool_choice: Option<ToolChoice>,
+    thinking: Option<ThinkingConfig>,
+}
+
+impl CountTokensRequestBuilder {
+    pub fn new(model: impl Into<String>, messages: Vec<Message>) -> Self {
+        Self { model: Some(model.into()), messages: Some(messages), ..Default::default() }
+    }
+
+    pub fn system(mut self, system: impl Into<SystemPrompt>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    pub fn tools(mut self, tools: Vec<Tool>) -> Self {
+        self.tools = Some(tools);
+        self
+    }
+
+    pub fn tool_choice(mut self, tool_choice: ToolChoice) -> Self {
+        self.tool_choice = Some(tool_choice);
+        self
+    }
+
+    pub fn thinking(mut self, thinking: ThinkingConfig) -> Self {
+        self.thinking = Some(thinking);
+        self
+    }
+
+    pub fn build(self) -> Result<CountTokensRequest, AnthropicError> {
+        let model = self.model.ok_or_else(|| AnthropicError::InvalidRequest("model is required".into()))?;
+        if model.is_empty() {
+            return Err(AnthropicError::InvalidRequest("model must not be empty".into()));
+        }
+        let messages = self.messages.ok_or_else(|| AnthropicError::InvalidRequest("messages is required".into()))?;
+        if messages.is_empty() {
+            return Err(AnthropicError::InvalidRequest("messages must not be empty".into()));
+        }
+        Ok(CountTokensRequest {
+            model,
+            messages,
+            system: self.system,
+            tools: self.tools,
+            tool_choice: self.tool_choice,
+            thinking: self.thinking,
+        })
+    }
+}
+
+/// Response from `POST /v1/messages/count_tokens`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct CountTokensResponse {
+    pub input_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MessagesRequestBuilder;
+    use serde_json::json;
+
+    #[test]
+    fn builder_roundtrip_from_messages_request() {
+        let req = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 100)
+            .system("be nice")
+            .tools(vec![Tool::new("t", "d", json!({}))])
+            .tool_choice(ToolChoice::Auto)
+            .thinking(ThinkingConfig::enabled(256))
+            .build()
+            .unwrap();
+
+        let ct = CountTokensRequest::from_messages_request(&req);
+        assert_eq!(ct.model, "claude");
+        assert_eq!(ct.messages.len(), 1);
+        assert!(ct.system.is_some());
+        assert!(ct.tools.is_some());
+        assert_eq!(ct.tool_choice, Some(ToolChoice::Auto));
+        assert_eq!(ct.thinking, Some(ThinkingConfig::enabled(256)));
+    }
+
+    #[test]
+    fn builder_rejects_empty_messages() {
+        let err = CountTokensRequestBuilder::new("m", vec![]).build().unwrap_err();
+        assert!(format!("{err}").contains("messages"));
+    }
+
+    #[test]
+    fn builder_rejects_empty_model() {
+        let err = CountTokensRequestBuilder::new("", vec![Message::user("hi")]).build().unwrap_err();
+        assert!(format!("{err}").contains("model"));
+    }
+
+    #[test]
+    fn request_serializes_minimum_fields_only() {
+        let req = CountTokensRequestBuilder::new("m", vec![Message::user("hi")]).build().unwrap();
+        let value = serde_json::to_value(&req).unwrap();
+        let obj = value.as_object().unwrap();
+        assert!(obj.contains_key("model"));
+        assert!(obj.contains_key("messages"));
+        assert!(!obj.contains_key("system"));
+        assert!(!obj.contains_key("tools"));
+        assert!(!obj.contains_key("tool_choice"));
+    }
+
+    #[test]
+    fn response_deserializes() {
+        let resp: CountTokensResponse = serde_json::from_value(json!({"input_tokens": 42})).unwrap();
+        assert_eq!(resp.input_tokens, 42);
+    }
+}

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -31,6 +31,7 @@ pub mod count_tokens;
 pub mod error;
 pub mod models;
 pub mod stream;
+pub mod tool_loop;
 pub mod types;
 
 pub use batches::{
@@ -42,3 +43,4 @@ pub use count_tokens::{CountTokensRequest, CountTokensRequestBuilder, CountToken
 pub use error::{AnthropicError, ApiError};
 pub use models::{ListModelsParams, Model, ModelList};
 pub use stream::{collect, collect_stream, StreamAccumulator};
+pub use tool_loop::{run_tool_loop, ToolLoopConfig, ToolOutput};

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -4,26 +4,44 @@
 //!
 //! ## Quickstart
 //! ```no_run
-//! use anthropic::types::{ContentBlock, Message, MessagesRequestBuilder, Role};
+//! use anthropic::types::{Message, MessagesRequestBuilder};
 //! use anthropic::Client;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let client = Client::from_env()?;
-//!     let messages = vec![Message {
-//!         role: Role::User,
-//!         content: vec![ContentBlock::text("Tell me a haiku about Rust.")],
-//!     }];
-//!
-//!     let request = MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", messages, 256)
-//!         .temperature(0.7)
-//!         .build()?;
+//!     let request = MessagesRequestBuilder::new(
+//!         "claude-3-5-sonnet-20240620",
+//!         vec![Message::user("Tell me a haiku about Rust.")],
+//!         256,
+//!     )
+//!     .temperature(0.7)
+//!     .build()?;
 //!
 //!     let response = client.messages(request).await?;
-//!     println!("{response:#?}");
+//!     println!("{}", response.text());
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## What's included
+//!
+//! - [`Client`] / [`ClientBuilder`] for the `/v1/messages` and
+//!   `/v1/messages/count_tokens` endpoints.
+//! - Models API: [`Client::list_models`](client::Client::list_models) and
+//!   [`Client::get_model`](client::Client::get_model).
+//! - Message Batches API: [`Client::create_batch`](client::Client::create_batch),
+//!   [`Client::list_batches`](client::Client::list_batches),
+//!   [`Client::get_batch`](client::Client::get_batch),
+//!   [`Client::cancel_batch`](client::Client::cancel_batch),
+//!   [`Client::delete_batch`](client::Client::delete_batch), and
+//!   [`Client::get_batch_results`](client::Client::get_batch_results) (JSONL-aware).
+//! - [`StreamAccumulator`] / [`collect_stream`] to fold a live SSE stream
+//!   into a fully materialized [`types::MessagesResponse`].
+//! - [`run_tool_loop`] to drive a tool-use conversation end-to-end.
+//! - Prompt-caching (`CacheControl`), extended thinking (`ThinkingConfig`),
+//!   service tier, image / document blocks, and all other modern request
+//!   fields are supported on [`types::MessagesRequestBuilder`].
 
 pub mod batches;
 pub mod client;

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -25,12 +25,17 @@
 //! }
 //! ```
 
+pub mod batches;
 pub mod client;
 pub mod count_tokens;
 pub mod error;
 pub mod models;
 pub mod types;
 
+pub use batches::{
+    BatchProcessingStatus, BatchRequest, BatchRequestCounts, BatchRequestResult, BatchResultItem, CreateBatchRequest,
+    ListBatchesParams, MessageBatch, MessageBatchList,
+};
 pub use client::{Client, ClientBuilder};
 pub use count_tokens::{CountTokensRequest, CountTokensRequestBuilder, CountTokensResponse};
 pub use error::{AnthropicError, ApiError};

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -30,6 +30,7 @@ pub mod client;
 pub mod count_tokens;
 pub mod error;
 pub mod models;
+pub mod stream;
 pub mod types;
 
 pub use batches::{
@@ -40,3 +41,4 @@ pub use client::{Client, ClientBuilder};
 pub use count_tokens::{CountTokensRequest, CountTokensRequestBuilder, CountTokensResponse};
 pub use error::{AnthropicError, ApiError};
 pub use models::{ListModelsParams, Model, ModelList};
+pub use stream::{collect, collect_stream, StreamAccumulator};

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -26,8 +26,12 @@
 //! ```
 
 pub mod client;
+pub mod count_tokens;
 pub mod error;
+pub mod models;
 pub mod types;
 
 pub use client::{Client, ClientBuilder};
+pub use count_tokens::{CountTokensRequest, CountTokensRequestBuilder, CountTokensResponse};
 pub use error::{AnthropicError, ApiError};
+pub use models::{ListModelsParams, Model, ModelList};

--- a/anthropic/src/models.rs
+++ b/anthropic/src/models.rs
@@ -1,0 +1,131 @@
+//! Types for the `/v1/models` endpoint.
+
+use serde::{Deserialize, Serialize};
+
+/// Model entry returned by the Anthropic API.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Model {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub model_type: String,
+    pub display_name: String,
+    pub created_at: String,
+}
+
+/// Paginated list response returned by `GET /v1/models`.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ModelList {
+    pub data: Vec<Model>,
+    #[serde(default)]
+    pub has_more: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+}
+
+/// Query parameters for paginating through the model list.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ListModelsParams {
+    pub before_id: Option<String>,
+    pub after_id: Option<String>,
+    pub limit: Option<u32>,
+}
+
+impl ListModelsParams {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn before_id(mut self, before_id: impl Into<String>) -> Self {
+        self.before_id = Some(before_id.into());
+        self
+    }
+
+    pub fn after_id(mut self, after_id: impl Into<String>) -> Self {
+        self.after_id = Some(after_id.into());
+        self
+    }
+
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Serialize the parameters as `(key, value)` tuples suitable for a query
+    /// string. Returns an empty vector when no parameters are set.
+    pub(crate) fn as_query(&self) -> Vec<(&'static str, String)> {
+        let mut out = Vec::new();
+        if let Some(before) = &self.before_id {
+            out.push(("before_id", before.clone()));
+        }
+        if let Some(after) = &self.after_id {
+            out.push(("after_id", after.clone()));
+        }
+        if let Some(limit) = self.limit {
+            out.push(("limit", limit.to_string()));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn model_deserializes() {
+        let model: Model = serde_json::from_value(json!({
+            "id": "claude-3-5-sonnet-20240620",
+            "type": "model",
+            "display_name": "Claude 3.5 Sonnet",
+            "created_at": "2024-06-20T00:00:00Z"
+        }))
+        .unwrap();
+        assert_eq!(model.id, "claude-3-5-sonnet-20240620");
+        assert_eq!(model.model_type, "model");
+        assert_eq!(model.display_name, "Claude 3.5 Sonnet");
+    }
+
+    #[test]
+    fn model_list_deserializes_with_pagination() {
+        let list: ModelList = serde_json::from_value(json!({
+            "data": [
+                {
+                    "id": "m1",
+                    "type": "model",
+                    "display_name": "M1",
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            ],
+            "has_more": true,
+            "first_id": "m1",
+            "last_id": "m1"
+        }))
+        .unwrap();
+        assert_eq!(list.data.len(), 1);
+        assert!(list.has_more);
+        assert_eq!(list.first_id.as_deref(), Some("m1"));
+    }
+
+    #[test]
+    fn model_list_deserializes_without_optional_fields() {
+        let list: ModelList = serde_json::from_value(json!({"data": []})).unwrap();
+        assert_eq!(list.data.len(), 0);
+        assert!(!list.has_more);
+        assert!(list.first_id.is_none());
+    }
+
+    #[test]
+    fn list_models_params_builds_query() {
+        let params = ListModelsParams::new().limit(10).after_id("abc");
+        let query = params.as_query();
+        assert_eq!(query, vec![("after_id", "abc".to_string()), ("limit", "10".to_string())]);
+    }
+
+    #[test]
+    fn list_models_params_empty_query() {
+        assert!(ListModelsParams::new().as_query().is_empty());
+    }
+}

--- a/anthropic/src/stream.rs
+++ b/anthropic/src/stream.rs
@@ -1,0 +1,429 @@
+//! Helpers for consuming a `messages_stream` response.
+//!
+//! [`StreamAccumulator`] folds every [`MessagesStreamEvent`] emitted by the
+//! Messages SSE stream into a complete [`MessagesResponse`], handling:
+//!
+//! - text deltas (`text_delta` on `text` blocks)
+//! - tool-use input deltas (`input_json_delta` on `tool_use` blocks — the
+//!   partial JSON chunks are concatenated and re-parsed on the terminal event)
+//! - extended-thinking deltas (`thinking_delta` and `signature_delta` on
+//!   `thinking` blocks)
+//! - `message_delta` events carrying stop reasons and usage updates
+//!
+//! It is designed so that callers can either stream one event at a time and
+//! pull the running state, or provide an async `Stream` and receive the final
+//! materialized response.
+
+use futures_util::StreamExt;
+use tokio_stream::Stream;
+
+use crate::client::MessagesResponseStream;
+use crate::error::AnthropicError;
+use crate::types::{
+    ContentBlock, ContentBlockDelta, MessageDelta, MessageDeltaUsage, MessagesResponse, MessagesStreamEvent, Role,
+    Usage,
+};
+
+/// Running state of a partially-received streamed message.
+///
+/// Call [`StreamAccumulator::push`] for every event, then [`StreamAccumulator::finish`]
+/// when the stream terminates.
+#[derive(Debug, Clone)]
+pub struct StreamAccumulator {
+    message: Option<MessagesResponse>,
+    /// Per-content-block buffer of incoming `input_json_delta` partial JSON.
+    partial_json: Vec<String>,
+    final_delta: Option<MessageDelta>,
+    finished: bool,
+}
+
+impl Default for StreamAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamAccumulator {
+    pub fn new() -> Self {
+        Self { message: None, partial_json: Vec::new(), final_delta: None, finished: false }
+    }
+
+    /// Return the current snapshot of the aggregated message, if `message_start`
+    /// has been observed.
+    pub fn snapshot(&self) -> Option<&MessagesResponse> {
+        self.message.as_ref()
+    }
+
+    /// True once a `message_stop` event has been observed.
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Apply a single stream event.
+    pub fn push(&mut self, event: MessagesStreamEvent) -> Result<(), AnthropicError> {
+        match event {
+            MessagesStreamEvent::MessageStart { message } => {
+                self.partial_json.clear();
+                self.message = Some(message);
+            }
+            MessagesStreamEvent::ContentBlockStart { index, content_block } => {
+                let message = self
+                    .message
+                    .as_mut()
+                    .ok_or_else(|| AnthropicError::InvalidRequest("stream event before message_start".into()))?;
+                while message.content.len() <= index {
+                    message.content.push(ContentBlock::text(""));
+                }
+                message.content[index] = content_block;
+                if self.partial_json.len() <= index {
+                    self.partial_json.resize(index + 1, String::new());
+                }
+                self.partial_json[index].clear();
+            }
+            MessagesStreamEvent::ContentBlockDelta { index, delta } => {
+                if self.message.is_none() {
+                    return Err(AnthropicError::InvalidRequest("stream event before message_start".into()));
+                }
+                if self.partial_json.len() <= index {
+                    self.partial_json.resize(index + 1, String::new());
+                }
+                let message = self.message.as_mut().expect("checked above");
+                if index >= message.content.len() {
+                    return Err(AnthropicError::InvalidRequest(format!(
+                        "content_block_delta for unknown index {index}"
+                    )));
+                }
+                match (&mut message.content[index], delta) {
+                    (ContentBlock::Text { text, .. }, ContentBlockDelta::TextDelta { text: delta }) => {
+                        text.push_str(&delta);
+                    }
+                    (ContentBlock::ToolUse { .. }, ContentBlockDelta::InputJsonDelta { partial_json }) => {
+                        self.partial_json[index].push_str(&partial_json);
+                    }
+                    (ContentBlock::Thinking { thinking, .. }, ContentBlockDelta::ThinkingDelta { thinking: delta }) => {
+                        thinking.push_str(&delta);
+                    }
+                    (
+                        ContentBlock::Thinking { signature, .. },
+                        ContentBlockDelta::SignatureDelta { signature: sig },
+                    ) => match signature {
+                        Some(existing) => existing.push_str(&sig),
+                        None => *signature = Some(sig),
+                    },
+                    (block, delta) => {
+                        return Err(AnthropicError::InvalidRequest(format!(
+                            "unexpected delta {delta:?} for content block {block:?}"
+                        )));
+                    }
+                }
+            }
+            MessagesStreamEvent::ContentBlockStop { index } => {
+                let buffer = self.partial_json.get(index).cloned();
+                let message = self
+                    .message
+                    .as_mut()
+                    .ok_or_else(|| AnthropicError::InvalidRequest("stream event before message_start".into()))?;
+                if let Some(ContentBlock::ToolUse { input, .. }) = message.content.get_mut(index) {
+                    if let Some(buffer) = buffer {
+                        if !buffer.is_empty() {
+                            *input = serde_json::from_str(&buffer).map_err(AnthropicError::Deserialize)?;
+                        }
+                    }
+                }
+                if let Some(buf) = self.partial_json.get_mut(index) {
+                    buf.clear();
+                }
+            }
+            MessagesStreamEvent::MessageDelta { delta, usage } => {
+                let message = self
+                    .message
+                    .as_mut()
+                    .ok_or_else(|| AnthropicError::InvalidRequest("stream event before message_start".into()))?;
+                if delta.stop_reason.is_some() {
+                    message.stop_reason = delta.stop_reason;
+                }
+                if delta.stop_sequence.is_some() {
+                    message.stop_sequence = delta.stop_sequence.clone();
+                }
+                merge_usage(&mut message.usage, &usage);
+                self.final_delta = Some(delta);
+            }
+            MessagesStreamEvent::MessageStop => {
+                self.finished = true;
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume the accumulator and return the final response.
+    ///
+    /// Returns [`AnthropicError::InvalidRequest`] if no `message_start` was
+    /// ever observed.
+    pub fn finish(self) -> Result<MessagesResponse, AnthropicError> {
+        self.message.ok_or_else(|| AnthropicError::InvalidRequest("stream ended before any message_start event".into()))
+    }
+}
+
+fn merge_usage(target: &mut Usage, delta: &MessageDeltaUsage) {
+    target.output_tokens = delta.output_tokens;
+    if let Some(input_tokens) = delta.input_tokens {
+        target.input_tokens = input_tokens;
+    }
+    if delta.cache_creation_input_tokens.is_some() {
+        target.cache_creation_input_tokens = delta.cache_creation_input_tokens;
+    }
+    if delta.cache_read_input_tokens.is_some() {
+        target.cache_read_input_tokens = delta.cache_read_input_tokens;
+    }
+}
+
+/// Drive a [`MessagesResponseStream`] (or any compatible [`Stream`]) to
+/// completion and return the fully-materialized response.
+pub async fn collect_stream<S>(mut stream: S) -> Result<MessagesResponse, AnthropicError>
+where
+    S: Stream<Item = Result<MessagesStreamEvent, AnthropicError>> + Unpin,
+{
+    let mut acc = StreamAccumulator::new();
+    while let Some(event) = stream.next().await {
+        acc.push(event?)?;
+    }
+    acc.finish()
+}
+
+/// Convenience alias of [`collect_stream`] that accepts the specific boxed
+/// stream returned by [`crate::client::Client::messages_stream`].
+pub async fn collect(stream: MessagesResponseStream) -> Result<MessagesResponse, AnthropicError> {
+    collect_stream(stream).await
+}
+
+/// Seed an empty [`MessagesResponse`] that the accumulator can populate when
+/// a provider sends a `message_start` without content blocks pre-populated.
+pub fn empty_response(model: impl Into<String>) -> MessagesResponse {
+    MessagesResponse {
+        id: String::new(),
+        message_type: "message".into(),
+        role: Role::Assistant,
+        content: Vec::new(),
+        model: model.into(),
+        stop_reason: None,
+        stop_sequence: None,
+        usage: Usage::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{MessageDelta, MessageDeltaUsage, StopReason};
+    use futures_util::stream;
+    use serde_json::json;
+
+    fn message_start() -> MessagesStreamEvent {
+        MessagesStreamEvent::MessageStart {
+            message: MessagesResponse {
+                id: "msg_1".into(),
+                message_type: "message".into(),
+                role: Role::Assistant,
+                content: Vec::new(),
+                model: "claude".into(),
+                stop_reason: None,
+                stop_sequence: None,
+                usage: Usage { input_tokens: 5, output_tokens: 0, ..Default::default() },
+            },
+        }
+    }
+
+    fn block_start_text(index: usize) -> MessagesStreamEvent {
+        MessagesStreamEvent::ContentBlockStart { index, content_block: ContentBlock::text("") }
+    }
+
+    fn text_delta(index: usize, text: &str) -> MessagesStreamEvent {
+        MessagesStreamEvent::ContentBlockDelta { index, delta: ContentBlockDelta::TextDelta { text: text.into() } }
+    }
+
+    #[test]
+    fn accumulates_text_blocks_into_response() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        acc.push(block_start_text(0)).unwrap();
+        acc.push(text_delta(0, "Hello, ")).unwrap();
+        acc.push(text_delta(0, "world!")).unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStop { index: 0 }).unwrap();
+        acc.push(MessagesStreamEvent::MessageDelta {
+            delta: MessageDelta { stop_reason: Some(StopReason::EndTurn), stop_sequence: None },
+            usage: MessageDeltaUsage {
+                output_tokens: 12,
+                input_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::MessageStop).unwrap();
+
+        assert!(acc.is_finished());
+        let response = acc.finish().unwrap();
+        assert_eq!(response.text(), "Hello, world!");
+        assert_eq!(response.stop_reason, Some(StopReason::EndTurn));
+        assert_eq!(response.usage.input_tokens, 5);
+        assert_eq!(response.usage.output_tokens, 12);
+    }
+
+    #[test]
+    fn accumulates_tool_use_input_json_deltas() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStart {
+            index: 0,
+            content_block: ContentBlock::tool_use("tu_1", "get_weather", json!({})),
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::InputJsonDelta { partial_json: "{\"city\": ".into() },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::InputJsonDelta { partial_json: "\"Paris\"}".into() },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStop { index: 0 }).unwrap();
+        acc.push(MessagesStreamEvent::MessageStop).unwrap();
+
+        let response = acc.finish().unwrap();
+        let tool_uses: Vec<_> = response.tool_uses().collect();
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].2, &json!({"city": "Paris"}));
+    }
+
+    #[test]
+    fn accumulates_thinking_and_signature_deltas() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStart { index: 0, content_block: ContentBlock::thinking("") })
+            .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::ThinkingDelta { thinking: "Let me ".into() },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::ThinkingDelta { thinking: "think...".into() },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::SignatureDelta { signature: "sig-abc".into() },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStop { index: 0 }).unwrap();
+        acc.push(MessagesStreamEvent::MessageStop).unwrap();
+
+        let response = acc.finish().unwrap();
+        match &response.content[0] {
+            ContentBlock::Thinking { thinking, signature } => {
+                assert_eq!(thinking, "Let me think...");
+                assert_eq!(signature.as_deref(), Some("sig-abc"));
+            }
+            other => panic!("expected Thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_delta_before_message_start() {
+        let mut acc = StreamAccumulator::new();
+        let err = acc.push(text_delta(0, "oops")).unwrap_err();
+        assert!(format!("{err}").contains("message_start"));
+    }
+
+    #[test]
+    fn rejects_delta_for_unknown_index() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        let err = acc.push(text_delta(5, "oops")).unwrap_err();
+        assert!(format!("{err}").contains("index 5"));
+    }
+
+    #[test]
+    fn rejects_mismatched_delta_kind() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        acc.push(block_start_text(0)).unwrap();
+        // text block cannot accept an input_json_delta
+        let err = acc
+            .push(MessagesStreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: ContentBlockDelta::InputJsonDelta { partial_json: "x".into() },
+            })
+            .unwrap_err();
+        assert!(format!("{err}").contains("unexpected delta"));
+    }
+
+    #[test]
+    fn finish_without_message_start_fails() {
+        let acc = StreamAccumulator::new();
+        let err = acc.finish().unwrap_err();
+        assert!(format!("{err}").contains("message_start"));
+    }
+
+    #[test]
+    fn reports_final_delta_usage_and_stop_sequence() {
+        let mut acc = StreamAccumulator::new();
+        acc.push(message_start()).unwrap();
+        acc.push(block_start_text(0)).unwrap();
+        acc.push(text_delta(0, "hi")).unwrap();
+        acc.push(MessagesStreamEvent::ContentBlockStop { index: 0 }).unwrap();
+        acc.push(MessagesStreamEvent::MessageDelta {
+            delta: MessageDelta { stop_reason: Some(StopReason::StopSequence), stop_sequence: Some("STOP".into()) },
+            usage: MessageDeltaUsage {
+                output_tokens: 7,
+                input_tokens: Some(11),
+                cache_creation_input_tokens: Some(3),
+                cache_read_input_tokens: Some(4),
+            },
+        })
+        .unwrap();
+        acc.push(MessagesStreamEvent::MessageStop).unwrap();
+
+        let response = acc.finish().unwrap();
+        assert_eq!(response.stop_reason, Some(StopReason::StopSequence));
+        assert_eq!(response.stop_sequence.as_deref(), Some("STOP"));
+        assert_eq!(response.usage.input_tokens, 11);
+        assert_eq!(response.usage.output_tokens, 7);
+        assert_eq!(response.usage.cache_creation_input_tokens, Some(3));
+        assert_eq!(response.usage.cache_read_input_tokens, Some(4));
+    }
+
+    #[tokio::test]
+    async fn collect_stream_builds_response_from_async_stream() {
+        let events: Vec<Result<MessagesStreamEvent, AnthropicError>> = vec![
+            Ok(message_start()),
+            Ok(block_start_text(0)),
+            Ok(text_delta(0, "hello")),
+            Ok(MessagesStreamEvent::ContentBlockStop { index: 0 }),
+            Ok(MessagesStreamEvent::MessageStop),
+        ];
+        let s = stream::iter(events);
+        let response = collect_stream(s).await.unwrap();
+        assert_eq!(response.text(), "hello");
+    }
+
+    #[tokio::test]
+    async fn collect_stream_propagates_errors() {
+        let err = AnthropicError::InvalidRequest("kaboom".into());
+        let events: Vec<Result<MessagesStreamEvent, AnthropicError>> = vec![Ok(message_start()), Err(err)];
+        let s = stream::iter(events);
+        let result = collect_stream(s).await;
+        assert!(matches!(result, Err(AnthropicError::InvalidRequest(_))));
+    }
+
+    #[test]
+    fn empty_response_helper_seeds_defaults() {
+        let resp = empty_response("claude");
+        assert_eq!(resp.model, "claude");
+        assert_eq!(resp.role, Role::Assistant);
+        assert!(resp.content.is_empty());
+    }
+}

--- a/anthropic/src/tool_loop.rs
+++ b/anthropic/src/tool_loop.rs
@@ -1,0 +1,151 @@
+//! High-level helper that drives the agentic "tool use" loop.
+//!
+//! Many real applications follow the same pattern: send a request to Claude,
+//! inspect the response for `tool_use` blocks, execute the tools locally, feed
+//! the results back into the conversation, and repeat until Claude returns a
+//! plain-text answer (or the iteration budget is exhausted).
+//!
+//! [`run_tool_loop`] captures that pattern behind a minimal callback-based API
+//! so callers only have to provide the tool executor.
+
+use std::future::Future;
+
+use crate::client::Client;
+use crate::error::AnthropicError;
+use crate::types::{ContentBlock, Message, MessagesRequest, MessagesResponse, Role};
+
+/// Result of executing a single tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolOutput {
+    pub content: String,
+    pub is_error: bool,
+}
+
+impl ToolOutput {
+    /// Successful tool result.
+    pub fn ok(content: impl Into<String>) -> Self {
+        Self { content: content.into(), is_error: false }
+    }
+
+    /// Tool-level error reported back to the model.
+    pub fn error(content: impl Into<String>) -> Self {
+        Self { content: content.into(), is_error: true }
+    }
+}
+
+/// Configuration for the tool loop.
+#[derive(Debug, Clone)]
+pub struct ToolLoopConfig {
+    /// Maximum number of model round-trips before the loop bails out.
+    pub max_iterations: usize,
+}
+
+impl Default for ToolLoopConfig {
+    fn default() -> Self {
+        Self { max_iterations: 8 }
+    }
+}
+
+impl ToolLoopConfig {
+    pub fn new(max_iterations: usize) -> Self {
+        Self { max_iterations }
+    }
+}
+
+/// Drive the "call model → run tools → feed results back" loop until Claude
+/// returns a tool-free response, an error propagates, or the iteration budget
+/// is exhausted.
+///
+/// `request` is cloned on every iteration with `messages` extended to contain
+/// the running transcript, so the original tool list, tool choice, system
+/// prompt, etc. are preserved throughout the loop.
+///
+/// The `executor` callback receives the tool name and input JSON and returns
+/// either a [`ToolOutput`] (success or tool-level error, both fed back to the
+/// model) or a propagated [`AnthropicError`] that aborts the loop.
+pub async fn run_tool_loop<F, Fut>(
+    client: &Client,
+    mut request: MessagesRequest,
+    mut executor: F,
+    config: ToolLoopConfig,
+) -> Result<MessagesResponse, AnthropicError>
+where
+    F: FnMut(String, serde_json::Value) -> Fut,
+    Fut: Future<Output = Result<ToolOutput, AnthropicError>>,
+{
+    if config.max_iterations == 0 {
+        return Err(AnthropicError::InvalidRequest("tool loop max_iterations must be non-zero".into()));
+    }
+
+    for _ in 0..config.max_iterations {
+        let response = client.messages(request.clone()).await?;
+
+        if !response.has_tool_use() {
+            return Ok(response);
+        }
+
+        // Collect tool calls BEFORE mutating the transcript so we can run
+        // every tool even if one of them errors.
+        let mut pending: Vec<(String, String, serde_json::Value)> = Vec::new();
+        for block in &response.content {
+            if let ContentBlock::ToolUse { id, name, input, .. } = block {
+                pending.push((id.clone(), name.clone(), input.clone()));
+            }
+        }
+
+        // Append the assistant turn to the transcript so the next request
+        // sends the full history back to Claude.
+        request.messages.push(Message::new(Role::Assistant, response.content.clone()));
+
+        let mut tool_results: Vec<ContentBlock> = Vec::with_capacity(pending.len());
+        for (id, name, input) in pending {
+            let output = executor(name, input).await?;
+            let block = if output.is_error {
+                ContentBlock::tool_result_error(id, output.content)
+            } else {
+                ContentBlock::tool_result_text(id, output.content)
+            };
+            tool_results.push(block);
+        }
+
+        request.messages.push(Message::new(Role::User, tool_results));
+    }
+
+    Err(AnthropicError::InvalidRequest(format!(
+        "tool loop exceeded {} iterations without reaching a final response",
+        config.max_iterations
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_output_helpers_set_is_error_correctly() {
+        let ok = ToolOutput::ok("done");
+        assert_eq!(ok.content, "done");
+        assert!(!ok.is_error);
+
+        let err = ToolOutput::error("nope");
+        assert_eq!(err.content, "nope");
+        assert!(err.is_error);
+    }
+
+    #[test]
+    fn tool_loop_config_default_and_custom() {
+        assert_eq!(ToolLoopConfig::default().max_iterations, 8);
+        assert_eq!(ToolLoopConfig::new(3).max_iterations, 3);
+    }
+
+    #[tokio::test]
+    async fn run_tool_loop_rejects_zero_max_iterations() {
+        // Build a throwaway client that we expect to never be called.
+        let client = Client::builder().api_key("x").api_base("http://127.0.0.1:1").build().unwrap();
+        let request = crate::types::MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10).build().unwrap();
+        let err = run_tool_loop(&client, request, |_n, _i| async { Ok(ToolOutput::ok("x")) }, ToolLoopConfig::new(0))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AnthropicError::InvalidRequest(_)));
+    }
+}

--- a/anthropic/src/types.rs
+++ b/anthropic/src/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AnthropicError;
 
+/// Role a message belongs to in a conversation.
 #[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Role {
@@ -11,28 +12,75 @@ pub enum Role {
     Assistant,
 }
 
+/// Prompt caching marker attached to content blocks, tools, and system prompts.
+///
+/// The Anthropic API only accepts `ephemeral` cache entries today, optionally
+/// with a custom TTL ("5m" or "1h").
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum CacheControl {
+    Ephemeral {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ttl: Option<String>,
+    },
+}
+
+impl CacheControl {
+    /// Default `{"type": "ephemeral"}` cache marker.
+    pub fn ephemeral() -> Self {
+        Self::Ephemeral { ttl: None }
+    }
+
+    /// `ephemeral` marker with a custom TTL string (e.g. "5m" or "1h").
+    pub fn ephemeral_ttl(ttl: impl Into<String>) -> Self {
+        Self::Ephemeral { ttl: Some(ttl.into()) }
+    }
+}
+
+/// Content block variants understood by the Messages API.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ContentBlock {
     Text {
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     Image {
         source: ImageSource,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
+    Document {
+        source: DocumentSource,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        citations: Option<CitationsConfig>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     ToolUse {
         id: String,
         name: String,
         input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     ToolResult {
         tool_use_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
         content: ToolResultContent,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     Thinking {
         thinking: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
     },
     RedactedThinking {
         data: String,
@@ -40,8 +88,129 @@ pub enum ContentBlock {
 }
 
 impl ContentBlock {
+    /// Plain text block.
     pub fn text(text: impl Into<String>) -> Self {
-        Self::Text { text: text.into() }
+        Self::Text { text: text.into(), cache_control: None }
+    }
+
+    /// Image block backed by inline base64 data.
+    pub fn image_base64(media_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Image {
+            source: ImageSource::Base64 { media_type: media_type.into(), data: data.into() },
+            cache_control: None,
+        }
+    }
+
+    /// Image block that references a remote URL.
+    pub fn image_url(url: impl Into<String>) -> Self {
+        Self::Image { source: ImageSource::Url { url: url.into() }, cache_control: None }
+    }
+
+    /// Document block backed by inline base64-encoded data.
+    pub fn document_base64(media_type: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::Document {
+            source: DocumentSource::Base64 { media_type: media_type.into(), data: data.into() },
+            title: None,
+            context: None,
+            citations: None,
+            cache_control: None,
+        }
+    }
+
+    /// Document block backed by a remote URL.
+    pub fn document_url(url: impl Into<String>) -> Self {
+        Self::Document {
+            source: DocumentSource::Url { url: url.into() },
+            title: None,
+            context: None,
+            citations: None,
+            cache_control: None,
+        }
+    }
+
+    /// Document block backed by inline text (useful for text files).
+    pub fn document_text(text: impl Into<String>) -> Self {
+        Self::Document {
+            source: DocumentSource::Text { media_type: "text/plain".into(), data: text.into() },
+            title: None,
+            context: None,
+            citations: None,
+            cache_control: None,
+        }
+    }
+
+    /// Tool-use block representing a call requested by the model.
+    pub fn tool_use(id: impl Into<String>, name: impl Into<String>, input: serde_json::Value) -> Self {
+        Self::ToolUse { id: id.into(), name: name.into(), input, cache_control: None }
+    }
+
+    /// Successful tool result, replying with plain text.
+    pub fn tool_result_text(tool_use_id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self::ToolResult {
+            tool_use_id: tool_use_id.into(),
+            is_error: None,
+            content: ToolResultContent::Text(text.into()),
+            cache_control: None,
+        }
+    }
+
+    /// Tool result with structured content blocks.
+    pub fn tool_result_blocks(tool_use_id: impl Into<String>, blocks: Vec<ContentBlock>) -> Self {
+        Self::ToolResult {
+            tool_use_id: tool_use_id.into(),
+            is_error: None,
+            content: ToolResultContent::Blocks(blocks),
+            cache_control: None,
+        }
+    }
+
+    /// Tool result marked as an error.
+    pub fn tool_result_error(tool_use_id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self::ToolResult {
+            tool_use_id: tool_use_id.into(),
+            is_error: Some(true),
+            content: ToolResultContent::Text(text.into()),
+            cache_control: None,
+        }
+    }
+
+    /// Thinking block (extended thinking output from the model).
+    pub fn thinking(thinking: impl Into<String>) -> Self {
+        Self::Thinking { thinking: thinking.into(), signature: None }
+    }
+
+    /// Attach a `cache_control` marker to a block that supports caching.
+    ///
+    /// Blocks that do not support caching (thinking / redacted thinking) are
+    /// returned unchanged.
+    pub fn with_cache_control(mut self, cache: CacheControl) -> Self {
+        match &mut self {
+            Self::Text { cache_control, .. }
+            | Self::Image { cache_control, .. }
+            | Self::Document { cache_control, .. }
+            | Self::ToolUse { cache_control, .. }
+            | Self::ToolResult { cache_control, .. } => {
+                *cache_control = Some(cache);
+            }
+            Self::Thinking { .. } | Self::RedactedThinking { .. } => {}
+        }
+        self
+    }
+
+    /// Extract the textual payload from this block if it has one.
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Self::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Return the tool-use id, name, and input if this block is a [`ContentBlock::ToolUse`].
+    pub fn as_tool_use(&self) -> Option<(&str, &str, &serde_json::Value)> {
+        match self {
+            Self::ToolUse { id, name, input, .. } => Some((id.as_str(), name.as_str(), input)),
+            _ => None,
+        }
     }
 }
 
@@ -49,6 +218,21 @@ impl ContentBlock {
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ImageSource {
     Base64 { media_type: String, data: String },
+    Url { url: String },
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum DocumentSource {
+    Base64 { media_type: String, data: String },
+    Text { media_type: String, data: String },
+    Url { url: String },
+    Content { content: Vec<ContentBlock> },
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct CitationsConfig {
+    pub enabled: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -64,11 +248,50 @@ pub struct Message {
     pub content: Vec<ContentBlock>,
 }
 
+impl Message {
+    /// Construct a user message whose entire content is a single text block.
+    pub fn user(text: impl Into<String>) -> Self {
+        Self { role: Role::User, content: vec![ContentBlock::text(text)] }
+    }
+
+    /// Construct an assistant message whose entire content is a single text block.
+    pub fn assistant(text: impl Into<String>) -> Self {
+        Self { role: Role::Assistant, content: vec![ContentBlock::text(text)] }
+    }
+
+    /// Construct a message with arbitrary content blocks.
+    pub fn new(role: Role, content: Vec<ContentBlock>) -> Self {
+        Self { role, content }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum SystemPrompt {
     Text(String),
     Blocks(Vec<ContentBlock>),
+}
+
+impl SystemPrompt {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text(text.into())
+    }
+
+    pub fn blocks(blocks: Vec<ContentBlock>) -> Self {
+        Self::Blocks(blocks)
+    }
+}
+
+impl From<&str> for SystemPrompt {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
+impl From<String> for SystemPrompt {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -82,6 +305,21 @@ pub struct Tool {
     pub name: String,
     pub description: String,
     pub input_schema: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl Tool {
+    /// Construct a tool definition without prompt caching.
+    pub fn new(name: impl Into<String>, description: impl Into<String>, input_schema: serde_json::Value) -> Self {
+        Self { name: name.into(), description: description.into(), input_schema, cache_control: None }
+    }
+
+    /// Attach a cache-control marker to this tool.
+    pub fn with_cache_control(mut self, cache: CacheControl) -> Self {
+        self.cache_control = Some(cache);
+        self
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -90,6 +328,33 @@ pub enum ToolChoice {
     Auto,
     Any,
     Tool { name: String },
+    None,
+}
+
+/// Extended-thinking configuration attached to a request.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ThinkingConfig {
+    Enabled { budget_tokens: u32 },
+    Disabled,
+}
+
+impl ThinkingConfig {
+    pub fn enabled(budget_tokens: u32) -> Self {
+        Self::Enabled { budget_tokens }
+    }
+
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+}
+
+/// Quality-of-service tier for a request.
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    Auto,
+    StandardOnly,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -115,6 +380,10 @@ pub struct MessagesRequest {
     pub tools: Option<Vec<Tool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
 }
 
 #[derive(Debug, Default)]
@@ -131,6 +400,8 @@ pub struct MessagesRequestBuilder {
     stream: Option<bool>,
     tools: Option<Vec<Tool>>,
     tool_choice: Option<ToolChoice>,
+    thinking: Option<ThinkingConfig>,
+    service_tier: Option<ServiceTier>,
 }
 
 impl MessagesRequestBuilder {
@@ -153,8 +424,8 @@ impl MessagesRequestBuilder {
         self
     }
 
-    pub fn system(mut self, system: SystemPrompt) -> Self {
-        self.system = Some(system);
+    pub fn system(mut self, system: impl Into<SystemPrompt>) -> Self {
+        self.system = Some(system.into());
         self
     }
 
@@ -198,13 +469,35 @@ impl MessagesRequestBuilder {
         self
     }
 
+    pub fn thinking(mut self, thinking: ThinkingConfig) -> Self {
+        self.thinking = Some(thinking);
+        self
+    }
+
+    pub fn service_tier(mut self, tier: ServiceTier) -> Self {
+        self.service_tier = Some(tier);
+        self
+    }
+
     pub fn build(self) -> Result<MessagesRequest, AnthropicError> {
+        let model = self.model.ok_or_else(|| AnthropicError::InvalidRequest("model is required".into()))?;
+        if model.is_empty() {
+            return Err(AnthropicError::InvalidRequest("model must not be empty".into()));
+        }
+        let messages = self.messages.ok_or_else(|| AnthropicError::InvalidRequest("messages is required".into()))?;
+        if messages.is_empty() {
+            return Err(AnthropicError::InvalidRequest("messages must not be empty".into()));
+        }
+        let max_tokens =
+            self.max_tokens.ok_or_else(|| AnthropicError::InvalidRequest("max_tokens is required".into()))?;
+        if max_tokens == 0 {
+            return Err(AnthropicError::InvalidRequest("max_tokens must be greater than zero".into()));
+        }
+
         Ok(MessagesRequest {
-            model: self.model.ok_or_else(|| AnthropicError::InvalidRequest("model is required".into()))?,
-            messages: self.messages.ok_or_else(|| AnthropicError::InvalidRequest("messages is required".into()))?,
-            max_tokens: self
-                .max_tokens
-                .ok_or_else(|| AnthropicError::InvalidRequest("max_tokens is required".into()))?,
+            model,
+            messages,
+            max_tokens,
             system: self.system,
             metadata: self.metadata,
             stop_sequences: self.stop_sequences,
@@ -214,6 +507,8 @@ impl MessagesRequestBuilder {
             stream: self.stream,
             tools: self.tools,
             tool_choice: self.tool_choice,
+            thinking: self.thinking,
+            service_tier: self.service_tier,
         })
     }
 }
@@ -229,10 +524,16 @@ pub enum StopReason {
     Refusal,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Usage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
@@ -248,16 +549,52 @@ pub struct MessagesResponse {
     pub usage: Usage,
 }
 
+impl MessagesResponse {
+    /// Concatenate every text block in the response into a single string.
+    pub fn text(&self) -> String {
+        let mut out = String::new();
+        for block in &self.content {
+            if let ContentBlock::Text { text, .. } = block {
+                out.push_str(text);
+            }
+        }
+        out
+    }
+
+    /// Borrow the first text block, if any.
+    pub fn first_text(&self) -> Option<&str> {
+        self.content.iter().find_map(|b| b.as_text())
+    }
+
+    /// Iterate over every tool-use block in the response.
+    pub fn tool_uses(&self) -> impl Iterator<Item = (&str, &str, &serde_json::Value)> {
+        self.content.iter().filter_map(|b| b.as_tool_use())
+    }
+
+    /// Returns `true` if the response contains at least one tool-use block.
+    pub fn has_tool_use(&self) -> bool {
+        self.tool_uses().next().is_some()
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ContentBlockDelta {
     TextDelta { text: String },
     InputJsonDelta { partial_json: String },
+    ThinkingDelta { thinking: String },
+    SignatureDelta { signature: String },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MessageDeltaUsage {
     pub output_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -269,10 +606,367 @@ pub struct MessageDelta {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum MessagesStreamEvent {
-    MessageStart { message: Message },
+    MessageStart { message: MessagesResponse },
     ContentBlockStart { index: usize, content_block: ContentBlock },
     ContentBlockDelta { index: usize, delta: ContentBlockDelta },
     ContentBlockStop { index: usize },
     MessageDelta { delta: MessageDelta, usage: MessageDeltaUsage },
     MessageStop,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn roundtrip<T>(value: &T, expected: serde_json::Value)
+    where
+        T: Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        let serialized = serde_json::to_value(value).expect("serialize");
+        assert_eq!(serialized, expected, "serialize mismatch");
+        let deserialized: T = serde_json::from_value(expected).expect("deserialize");
+        assert_eq!(&deserialized, value, "roundtrip mismatch");
+    }
+
+    #[test]
+    fn content_block_text_serializes_without_cache_control() {
+        roundtrip(&ContentBlock::text("hello"), json!({"type": "text", "text": "hello"}));
+    }
+
+    #[test]
+    fn content_block_text_with_cache_control() {
+        let block = ContentBlock::text("hello").with_cache_control(CacheControl::ephemeral());
+        roundtrip(
+            &block,
+            json!({
+                "type": "text",
+                "text": "hello",
+                "cache_control": {"type": "ephemeral"}
+            }),
+        );
+    }
+
+    #[test]
+    fn cache_control_ttl_variant_roundtrip() {
+        roundtrip(&CacheControl::ephemeral_ttl("1h"), json!({"type": "ephemeral", "ttl": "1h"}));
+    }
+
+    #[test]
+    fn content_block_image_base64() {
+        let block = ContentBlock::image_base64("image/png", "YmFzZTY0");
+        roundtrip(
+            &block,
+            json!({
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": "YmFzZTY0"}
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_image_url() {
+        let block = ContentBlock::image_url("https://example.com/a.png");
+        roundtrip(
+            &block,
+            json!({
+                "type": "image",
+                "source": {"type": "url", "url": "https://example.com/a.png"}
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_tool_use_roundtrip() {
+        let block = ContentBlock::tool_use("tu_1", "get_weather", json!({"city": "Paris"}));
+        roundtrip(
+            &block,
+            json!({
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"}
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_tool_result_text_ok() {
+        let block = ContentBlock::tool_result_text("tu_1", "sunny");
+        roundtrip(
+            &block,
+            json!({
+                "type": "tool_result",
+                "tool_use_id": "tu_1",
+                "content": "sunny"
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_tool_result_error() {
+        let block = ContentBlock::tool_result_error("tu_1", "boom");
+        roundtrip(
+            &block,
+            json!({
+                "type": "tool_result",
+                "tool_use_id": "tu_1",
+                "is_error": true,
+                "content": "boom"
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_tool_result_with_blocks() {
+        let block = ContentBlock::tool_result_blocks("tu_1", vec![ContentBlock::text("inner")]);
+        let expected = json!({
+            "type": "tool_result",
+            "tool_use_id": "tu_1",
+            "content": [{"type": "text", "text": "inner"}]
+        });
+        roundtrip(&block, expected);
+    }
+
+    #[test]
+    fn content_block_thinking_with_signature() {
+        let block = ContentBlock::Thinking { thinking: "musing".into(), signature: Some("sig".into()) };
+        roundtrip(&block, json!({"type": "thinking", "thinking": "musing", "signature": "sig"}));
+    }
+
+    #[test]
+    fn content_block_document_url_roundtrip() {
+        let block = ContentBlock::document_url("https://example.com/a.pdf");
+        roundtrip(
+            &block,
+            json!({
+                "type": "document",
+                "source": {"type": "url", "url": "https://example.com/a.pdf"}
+            }),
+        );
+    }
+
+    #[test]
+    fn content_block_document_base64_with_title() {
+        let block = match ContentBlock::document_base64("application/pdf", "ZGF0YQ==") {
+            ContentBlock::Document { source, .. } => ContentBlock::Document {
+                source,
+                title: Some("Book".into()),
+                context: None,
+                citations: Some(CitationsConfig { enabled: true }),
+                cache_control: None,
+            },
+            other => panic!("unexpected: {other:?}"),
+        };
+        roundtrip(
+            &block,
+            json!({
+                "type": "document",
+                "source": {"type": "base64", "media_type": "application/pdf", "data": "ZGF0YQ=="},
+                "title": "Book",
+                "citations": {"enabled": true}
+            }),
+        );
+    }
+
+    #[test]
+    fn tool_serializes_with_optional_cache_control() {
+        let tool = Tool::new("get_weather", "fetch weather", json!({"type": "object"}));
+        roundtrip(
+            &tool,
+            json!({
+                "name": "get_weather",
+                "description": "fetch weather",
+                "input_schema": {"type": "object"}
+            }),
+        );
+
+        let cached = tool.with_cache_control(CacheControl::ephemeral());
+        let value = serde_json::to_value(&cached).unwrap();
+        assert_eq!(value["cache_control"], json!({"type": "ephemeral"}));
+    }
+
+    #[test]
+    fn tool_choice_none_variant_serializes() {
+        let choice = ToolChoice::None;
+        roundtrip(&choice, json!({"type": "none"}));
+    }
+
+    #[test]
+    fn thinking_config_enabled_serializes() {
+        roundtrip(&ThinkingConfig::enabled(1024), json!({"type": "enabled", "budget_tokens": 1024}));
+    }
+
+    #[test]
+    fn service_tier_serializes_snake_case() {
+        roundtrip(&ServiceTier::StandardOnly, json!("standard_only"));
+    }
+
+    #[test]
+    fn messages_request_builder_rejects_empty_messages() {
+        let err = MessagesRequestBuilder::new("m", vec![], 100).build().unwrap_err();
+        assert!(format!("{err}").contains("messages"));
+    }
+
+    #[test]
+    fn messages_request_builder_rejects_zero_max_tokens() {
+        let err = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 0).build().unwrap_err();
+        assert!(format!("{err}").contains("max_tokens"));
+    }
+
+    #[test]
+    fn messages_request_builder_rejects_empty_model() {
+        let err = MessagesRequestBuilder::new("", vec![Message::user("hi")], 10).build().unwrap_err();
+        assert!(format!("{err}").contains("model"));
+    }
+
+    #[test]
+    fn messages_request_builder_requires_model() {
+        let err =
+            MessagesRequestBuilder::default().messages(vec![Message::user("hi")]).max_tokens(10).build().unwrap_err();
+        assert!(format!("{err}").contains("model"));
+    }
+
+    #[test]
+    fn messages_request_builder_builds_full_request() {
+        let req = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 512)
+            .temperature(0.2)
+            .top_p(0.9)
+            .top_k(40)
+            .system("be helpful")
+            .thinking(ThinkingConfig::enabled(1024))
+            .service_tier(ServiceTier::Auto)
+            .tools(vec![Tool::new("t", "d", json!({}))])
+            .tool_choice(ToolChoice::Auto)
+            .build()
+            .unwrap();
+        assert_eq!(req.model, "claude");
+        assert_eq!(req.max_tokens, 512);
+        assert_eq!(req.temperature, Some(0.2));
+        assert_eq!(req.top_p, Some(0.9));
+        assert_eq!(req.top_k, Some(40));
+        assert_eq!(req.thinking, Some(ThinkingConfig::enabled(1024)));
+        assert_eq!(req.service_tier, Some(ServiceTier::Auto));
+        assert!(matches!(req.system, Some(SystemPrompt::Text(_))));
+    }
+
+    #[test]
+    fn messages_request_skips_none_fields_in_serialization() {
+        let req = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10).build().unwrap();
+        let value = serde_json::to_value(&req).unwrap();
+        let obj = value.as_object().unwrap();
+        assert!(obj.contains_key("model"));
+        assert!(obj.contains_key("messages"));
+        assert!(obj.contains_key("max_tokens"));
+        assert!(!obj.contains_key("temperature"));
+        assert!(!obj.contains_key("thinking"));
+        assert!(!obj.contains_key("service_tier"));
+    }
+
+    #[test]
+    fn stop_reason_roundtrips_pause_and_refusal() {
+        roundtrip(&StopReason::PauseTurn, json!("pause_turn"));
+        roundtrip(&StopReason::Refusal, json!("refusal"));
+    }
+
+    #[test]
+    fn usage_deserializes_with_only_required_fields() {
+        let usage: Usage = serde_json::from_value(json!({"input_tokens": 12, "output_tokens": 5})).unwrap();
+        assert_eq!(usage.input_tokens, 12);
+        assert_eq!(usage.output_tokens, 5);
+        assert!(usage.cache_creation_input_tokens.is_none());
+        assert!(usage.cache_read_input_tokens.is_none());
+    }
+
+    #[test]
+    fn usage_deserializes_with_cache_fields() {
+        let usage: Usage = serde_json::from_value(json!({
+            "input_tokens": 12,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 100,
+            "cache_read_input_tokens": 40,
+            "service_tier": "auto"
+        }))
+        .unwrap();
+        assert_eq!(usage.cache_creation_input_tokens, Some(100));
+        assert_eq!(usage.cache_read_input_tokens, Some(40));
+        assert_eq!(usage.service_tier.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn messages_response_text_concats_text_blocks() {
+        let resp = MessagesResponse {
+            id: "msg_1".into(),
+            message_type: "message".into(),
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::text("hello "),
+                ContentBlock::tool_use("tu_1", "t", json!({})),
+                ContentBlock::text("world"),
+            ],
+            model: "claude".into(),
+            stop_reason: Some(StopReason::EndTurn),
+            stop_sequence: None,
+            usage: Usage::default(),
+        };
+        assert_eq!(resp.text(), "hello world");
+        assert_eq!(resp.first_text(), Some("hello "));
+        assert!(resp.has_tool_use());
+        let tool_uses: Vec<_> = resp.tool_uses().collect();
+        assert_eq!(tool_uses.len(), 1);
+        assert_eq!(tool_uses[0].0, "tu_1");
+        assert_eq!(tool_uses[0].1, "t");
+    }
+
+    #[test]
+    fn stream_event_thinking_delta_roundtrip() {
+        let evt = MessagesStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentBlockDelta::ThinkingDelta { thinking: "...".into() },
+        };
+        roundtrip(
+            &evt,
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "thinking_delta", "thinking": "..."}
+            }),
+        );
+    }
+
+    #[test]
+    fn stream_event_signature_delta_roundtrip() {
+        let evt = MessagesStreamEvent::ContentBlockDelta {
+            index: 1,
+            delta: ContentBlockDelta::SignatureDelta { signature: "abc".into() },
+        };
+        roundtrip(
+            &evt,
+            json!({
+                "type": "content_block_delta",
+                "index": 1,
+                "delta": {"type": "signature_delta", "signature": "abc"}
+            }),
+        );
+    }
+
+    #[test]
+    fn system_prompt_text_conversion() {
+        let prompt: SystemPrompt = "hello".into();
+        assert_eq!(prompt, SystemPrompt::Text("hello".into()));
+        let prompt: SystemPrompt = String::from("world").into();
+        assert_eq!(prompt, SystemPrompt::Text("world".into()));
+    }
+
+    #[test]
+    fn message_helpers_construct_single_text_blocks() {
+        let m = Message::user("hi");
+        assert_eq!(m.role, Role::User);
+        assert_eq!(m.content.len(), 1);
+        assert_eq!(m.content[0].as_text(), Some("hi"));
+
+        let m = Message::assistant("bye");
+        assert_eq!(m.role, Role::Assistant);
+        assert_eq!(m.content[0].as_text(), Some("bye"));
+    }
 }

--- a/anthropic/tests/client_batches.rs
+++ b/anthropic/tests/client_batches.rs
@@ -1,0 +1,197 @@
+//! Integration tests for the Message Batches API.
+
+use anthropic::batches::{
+    BatchProcessingStatus, BatchRequest, BatchRequestResult, CreateBatchRequest, ListBatchesParams,
+};
+use anthropic::types::{Message, MessagesRequestBuilder};
+use anthropic::{AnthropicError, Client};
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client(server: &MockServer) -> Client {
+    Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap()
+}
+
+fn sample_request() -> anthropic::types::MessagesRequest {
+    MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("hello")], 64).build().unwrap()
+}
+
+fn sample_batch_json(id: &str, status: &str) -> serde_json::Value {
+    json!({
+        "id": id,
+        "type": "message_batch",
+        "processing_status": status,
+        "request_counts": {
+            "processing": 1,
+            "succeeded": 0,
+            "errored": 0,
+            "canceled": 0,
+            "expired": 0
+        },
+        "created_at": "2024-10-01T00:00:00Z",
+        "expires_at": "2024-10-02T00:00:00Z"
+    })
+}
+
+#[tokio::test]
+async fn create_batch_sends_request_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages/batches"))
+        .and(body_json(json!({
+            "requests": [
+                {
+                    "custom_id": "req_1",
+                    "params": {
+                        "model": "claude-3-5-sonnet-20240620",
+                        "messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+                        "max_tokens": 64
+                    }
+                }
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_batch_json("msgbatch_01", "in_progress")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let batch =
+        client.create_batch(CreateBatchRequest::new(vec![BatchRequest::new("req_1", sample_request())])).await.unwrap();
+    assert_eq!(batch.id, "msgbatch_01");
+    assert_eq!(batch.processing_status, BatchProcessingStatus::InProgress);
+    assert!(!batch.is_complete());
+}
+
+#[tokio::test]
+async fn create_batch_rejects_empty_requests_locally() {
+    let server = MockServer::start().await;
+    let client = client(&server);
+    // Must not hit the server when validation fails.
+    let err = client.create_batch(CreateBatchRequest::new(vec![])).await.unwrap_err();
+    assert!(matches!(err, AnthropicError::InvalidRequest(_)));
+}
+
+#[tokio::test]
+async fn list_batches_forwards_pagination() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/messages/batches"))
+        .and(query_param("limit", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [sample_batch_json("msgbatch_01", "ended")],
+            "has_more": false,
+            "first_id": "msgbatch_01",
+            "last_id": "msgbatch_01"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let list = client.list_batches(&ListBatchesParams::new().limit(3)).await.unwrap();
+    assert_eq!(list.data.len(), 1);
+    assert!(list.data[0].is_complete());
+}
+
+#[tokio::test]
+async fn get_batch_fetches_by_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/messages/batches/msgbatch_42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_batch_json("msgbatch_42", "ended")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let batch = client.get_batch("msgbatch_42").await.unwrap();
+    assert_eq!(batch.id, "msgbatch_42");
+    assert!(batch.is_complete());
+}
+
+#[tokio::test]
+async fn cancel_batch_posts_to_cancel_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages/batches/msgbatch_99/cancel"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_batch_json("msgbatch_99", "canceling")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let batch = client.cancel_batch("msgbatch_99").await.unwrap();
+    assert_eq!(batch.processing_status, BatchProcessingStatus::Canceling);
+}
+
+#[tokio::test]
+async fn delete_batch_sends_delete_verb() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/messages/batches/msgbatch_99"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msgbatch_99",
+            "type": "message_batch_deleted"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let body = client.delete_batch("msgbatch_99").await.unwrap();
+    assert_eq!(body["id"], "msgbatch_99");
+}
+
+#[tokio::test]
+async fn get_batch_results_parses_jsonl() {
+    let server = MockServer::start().await;
+
+    let body = r#"{"custom_id":"req_1","result":{"type":"succeeded","message":{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"done"}],"model":"claude","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":1}}}}
+{"custom_id":"req_2","result":{"type":"canceled"}}
+"#;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/messages/batches/msgbatch_01/results"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let items = client.get_batch_results("msgbatch_01").await.unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].custom_id, "req_1");
+    match &items[0].result {
+        BatchRequestResult::Succeeded { message } => assert_eq!(message.text(), "done"),
+        other => panic!("expected Succeeded, got {other:?}"),
+    }
+    assert!(matches!(items[1].result, BatchRequestResult::Canceled));
+}
+
+#[tokio::test]
+async fn batch_endpoints_surface_api_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/messages/batches/nope"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "type": "error",
+            "error": {"type": "not_found_error", "message": "batch not found"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let err = client.get_batch("nope").await.unwrap_err();
+    match err {
+        AnthropicError::Api(api) => assert_eq!(api.error_type, "not_found_error"),
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}

--- a/anthropic/tests/client_count_tokens.rs
+++ b/anthropic/tests/client_count_tokens.rs
@@ -1,0 +1,61 @@
+//! Integration tests for `Client::count_tokens`.
+
+use anthropic::count_tokens::CountTokensRequestBuilder;
+use anthropic::types::Message;
+use anthropic::Client;
+use serde_json::json;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn count_tokens_returns_input_token_count() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages/count_tokens"))
+        .and(header("x-api-key", "test-key"))
+        .and(body_json(json!({
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi there"}]}
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"input_tokens": 17})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let request =
+        CountTokensRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("hi there")]).build().unwrap();
+
+    let response = client.count_tokens(request).await.expect("count_tokens");
+    assert_eq!(response.input_tokens, 17);
+}
+
+#[tokio::test]
+async fn count_tokens_surfaces_api_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages/count_tokens"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "type": "error",
+            "error": {
+                "type": "authentication_error",
+                "message": "invalid api key"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let request = CountTokensRequestBuilder::new("m", vec![Message::user("hi")]).build().unwrap();
+    let err = client.count_tokens(request).await.unwrap_err();
+    match err {
+        anthropic::AnthropicError::Api(api) => {
+            assert_eq!(api.error_type, "authentication_error");
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}

--- a/anthropic/tests/client_messages.rs
+++ b/anthropic/tests/client_messages.rs
@@ -1,0 +1,182 @@
+//! Integration tests for `Client::messages` using a wiremock-backed server.
+
+use anthropic::types::{Message, MessagesRequestBuilder, Role, StopReason};
+use anthropic::{AnthropicError, Client};
+use serde_json::json;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn build_client(server: &MockServer) -> Client {
+    Client::builder().api_key("test-key").api_base(server.uri()).build().expect("client")
+}
+
+fn sample_request() -> anthropic::types::MessagesRequest {
+    MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("hi")], 128).build().unwrap()
+}
+
+#[tokio::test]
+async fn messages_sends_correct_headers_and_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("anthropic-version", "2023-06-01"))
+        .and(header("content-type", "application/json"))
+        .and(body_json(json!({
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+            ],
+            "max_tokens": 128
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_01",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "model": "claude-3-5-sonnet-20240620",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 5, "output_tokens": 2}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let response = client.messages(sample_request()).await.expect("ok");
+
+    assert_eq!(response.id, "msg_01");
+    assert_eq!(response.role, Role::Assistant);
+    assert_eq!(response.text(), "hello");
+    assert_eq!(response.stop_reason, Some(StopReason::EndTurn));
+    assert_eq!(response.usage.input_tokens, 5);
+    assert_eq!(response.usage.output_tokens, 2);
+}
+
+#[tokio::test]
+async fn messages_beta_header_is_forwarded() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("anthropic-beta", "prompt-caching-2024-07-31"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_02",
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": "claude",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 1, "output_tokens": 0}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client =
+        Client::builder().api_key("test-key").api_base(server.uri()).beta("prompt-caching-2024-07-31").build().unwrap();
+
+    client.messages(sample_request()).await.expect("ok");
+}
+
+#[tokio::test]
+async fn messages_surfaces_api_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "messages.0.content.0: missing field"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let err = client.messages(sample_request()).await.unwrap_err();
+    match err {
+        AnthropicError::Api(api) => {
+            assert_eq!(api.error_type, "invalid_request_error");
+            assert!(api.message.contains("missing"));
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn messages_surfaces_unexpected_response_bodies() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("gateway down"))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let err = client.messages(sample_request()).await.unwrap_err();
+    match err {
+        AnthropicError::UnexpectedResponse { status, body } => {
+            assert_eq!(status, 500);
+            assert_eq!(body, "gateway down");
+        }
+        other => panic!("expected UnexpectedResponse, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn messages_rejects_stream_true_requests() {
+    let server = MockServer::start().await;
+    let client = build_client(&server);
+
+    let request = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 10).stream(true).build().unwrap();
+    let err = client.messages(request).await.unwrap_err();
+    assert!(matches!(err, AnthropicError::InvalidRequest(_)));
+}
+
+#[tokio::test]
+async fn messages_preserves_conversation_roundtrip() {
+    let server = MockServer::start().await;
+
+    // Echo back a tool_use response so we can verify extractor helpers.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_03",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Calling tool. "},
+                {
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"}
+                }
+            ],
+            "model": "claude",
+            "stop_reason": "tool_use",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 8, "output_tokens": 12}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let response = client.messages(sample_request()).await.unwrap();
+
+    assert!(response.has_tool_use());
+    assert_eq!(response.first_text(), Some("Calling tool. "));
+    let tool_uses: Vec<_> = response.tool_uses().collect();
+    assert_eq!(tool_uses.len(), 1);
+    let (id, name, input) = tool_uses[0];
+    assert_eq!(id, "tu_1");
+    assert_eq!(name, "get_weather");
+    assert_eq!(input["city"], "Paris");
+}

--- a/anthropic/tests/client_models.rs
+++ b/anthropic/tests/client_models.rs
@@ -1,0 +1,112 @@
+//! Integration tests for `Client::list_models` and `Client::get_model`.
+
+use anthropic::models::ListModelsParams;
+use anthropic::Client;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn list_models_returns_all_models() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {
+                    "id": "claude-3-5-sonnet-20240620",
+                    "type": "model",
+                    "display_name": "Claude 3.5 Sonnet",
+                    "created_at": "2024-06-20T00:00:00Z"
+                },
+                {
+                    "id": "claude-3-opus-20240229",
+                    "type": "model",
+                    "display_name": "Claude 3 Opus",
+                    "created_at": "2024-02-29T00:00:00Z"
+                }
+            ],
+            "has_more": false,
+            "first_id": "claude-3-5-sonnet-20240620",
+            "last_id": "claude-3-opus-20240229"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let list = client.list_models(&ListModelsParams::new()).await.unwrap();
+    assert_eq!(list.data.len(), 2);
+    assert_eq!(list.data[0].id, "claude-3-5-sonnet-20240620");
+    assert!(!list.has_more);
+}
+
+#[tokio::test]
+async fn list_models_forwards_pagination_parameters() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .and(query_param("limit", "5"))
+        .and(query_param("after_id", "claude-3-opus-20240229"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [],
+            "has_more": false
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let params = ListModelsParams::new().limit(5).after_id("claude-3-opus-20240229");
+    client.list_models(&params).await.unwrap();
+}
+
+#[tokio::test]
+async fn get_model_returns_single_model() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models/claude-3-5-sonnet-20240620"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "claude-3-5-sonnet-20240620",
+            "type": "model",
+            "display_name": "Claude 3.5 Sonnet",
+            "created_at": "2024-06-20T00:00:00Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let model = client.get_model("claude-3-5-sonnet-20240620").await.unwrap();
+    assert_eq!(model.id, "claude-3-5-sonnet-20240620");
+    assert_eq!(model.display_name, "Claude 3.5 Sonnet");
+}
+
+#[tokio::test]
+async fn get_model_surfaces_not_found_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models/unknown"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "type": "error",
+            "error": {
+                "type": "not_found_error",
+                "message": "model unknown not found"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let client = Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap();
+    let err = client.get_model("unknown").await.unwrap_err();
+    match err {
+        anthropic::AnthropicError::Api(api) => {
+            assert_eq!(api.error_type, "not_found_error");
+        }
+        other => panic!("expected Api error, got {other:?}"),
+    }
+}

--- a/anthropic/tests/tool_loop.rs
+++ b/anthropic/tests/tool_loop.rs
@@ -1,0 +1,280 @@
+//! Integration tests for `run_tool_loop` against a wiremock-backed server.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anthropic::tool_loop::{run_tool_loop, ToolLoopConfig, ToolOutput};
+use anthropic::types::{Message, MessagesRequestBuilder, Tool, ToolChoice};
+use anthropic::{AnthropicError, Client};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client(server: &MockServer) -> Client {
+    Client::builder().api_key("test-key").api_base(server.uri()).build().unwrap()
+}
+
+fn tool_request() -> anthropic::types::MessagesRequest {
+    MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", vec![Message::user("What's the weather in Paris?")], 256)
+        .tools(vec![Tool::new(
+            "get_weather",
+            "Fetch the current weather for a city",
+            json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }),
+        )])
+        .tool_choice(ToolChoice::Auto)
+        .build()
+        .unwrap()
+}
+
+fn tool_use_response(id: &str, city: &str) -> serde_json::Value {
+    json!({
+        "id": "msg_tool",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": id,
+                "name": "get_weather",
+                "input": {"city": city}
+            }
+        ],
+        "model": "claude-3-5-sonnet-20240620",
+        "stop_reason": "tool_use",
+        "stop_sequence": null,
+        "usage": {"input_tokens": 20, "output_tokens": 15}
+    })
+}
+
+fn text_response(text: &str) -> serde_json::Value {
+    json!({
+        "id": "msg_final",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+        "model": "claude-3-5-sonnet-20240620",
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {"input_tokens": 40, "output_tokens": 12}
+    })
+}
+
+#[tokio::test]
+async fn tool_loop_runs_single_tool_then_returns_final_response() {
+    let server = MockServer::start().await;
+
+    // First call: model asks for a tool. Second call: model returns plain text.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_use_response("tu_1", "Paris")))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(text_response("It's sunny in Paris.")))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+
+    let response = run_tool_loop(
+        &client,
+        tool_request(),
+        move |name, input| {
+            let call_count = Arc::clone(&call_count_clone);
+            async move {
+                call_count.fetch_add(1, Ordering::SeqCst);
+                assert_eq!(name, "get_weather");
+                assert_eq!(input["city"], "Paris");
+                Ok(ToolOutput::ok("sunny, 22C"))
+            }
+        },
+        ToolLoopConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.text(), "It's sunny in Paris.");
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn tool_loop_handles_multiple_tool_calls_in_one_turn() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_tool",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Checking both cities."},
+                {"type": "tool_use", "id": "tu_1", "name": "get_weather", "input": {"city": "Paris"}},
+                {"type": "tool_use", "id": "tu_2", "name": "get_weather", "input": {"city": "Rome"}}
+            ],
+            "model": "claude-3-5-sonnet-20240620",
+            "stop_reason": "tool_use",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 20, "output_tokens": 15}
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(text_response("Paris is sunny, Rome is rainy.")))
+        .mount(&server)
+        .await;
+
+    let calls = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let calls_clone = Arc::clone(&calls);
+
+    let client = client(&server);
+    let response = run_tool_loop(
+        &client,
+        tool_request(),
+        move |_name, input| {
+            let calls = Arc::clone(&calls_clone);
+            async move {
+                let city = input["city"].as_str().unwrap().to_string();
+                calls.lock().unwrap().push(city.clone());
+                let result = if city == "Paris" { "sunny" } else { "rainy" };
+                Ok(ToolOutput::ok(format!("{city}: {result}")))
+            }
+        },
+        ToolLoopConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.text(), "Paris is sunny, Rome is rainy.");
+    let locked = calls.lock().unwrap();
+    assert_eq!(locked.len(), 2);
+    assert!(locked.contains(&"Paris".to_string()));
+    assert!(locked.contains(&"Rome".to_string()));
+}
+
+#[tokio::test]
+async fn tool_loop_propagates_tool_errors_to_model() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_use_response("tu_1", "Unknown")))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(text_response("That city is unknown.")))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let response = run_tool_loop(
+        &client,
+        tool_request(),
+        |_name, _input| async move { Ok(ToolOutput::error("city not found")) },
+        ToolLoopConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.text(), "That city is unknown.");
+}
+
+#[tokio::test]
+async fn tool_loop_bails_out_on_iteration_limit() {
+    let server = MockServer::start().await;
+
+    // The mock always returns a tool_use response, so the loop never terminates.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_use_response("tu_1", "Paris")))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let err =
+        run_tool_loop(&client, tool_request(), |_n, _i| async { Ok(ToolOutput::ok("sunny")) }, ToolLoopConfig::new(2))
+            .await
+            .unwrap_err();
+
+    match err {
+        AnthropicError::InvalidRequest(msg) => {
+            assert!(msg.contains("2 iterations"));
+        }
+        other => panic!("expected InvalidRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn tool_loop_propagates_executor_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_use_response("tu_1", "Paris")))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let err = run_tool_loop(
+        &client,
+        tool_request(),
+        |_n, _i| async move { Err(AnthropicError::InvalidRequest("tool blew up".into())) },
+        ToolLoopConfig::default(),
+    )
+    .await
+    .unwrap_err();
+
+    match err {
+        AnthropicError::InvalidRequest(msg) => assert_eq!(msg, "tool blew up"),
+        other => panic!("expected InvalidRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn tool_loop_returns_directly_when_no_tool_use() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(text_response("Just chatting.")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+    let response = run_tool_loop(
+        &client,
+        tool_request(),
+        move |_n, _i| {
+            let c = Arc::clone(&call_count_clone);
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(ToolOutput::ok("never called"))
+            }
+        },
+        ToolLoopConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.text(), "Just chatting.");
+    assert_eq!(call_count.load(Ordering::SeqCst), 0);
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "basic-messages",
     "streaming-messages",
+    "tool-loop",
 ]
 resolver = "2"

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,4 +19,8 @@ cargo run
 ## List of examples
 
 - [basic-messages](basic-messages): A basic example of the Messages API.
-- [streaming-messages](streaming-messages): An example of streaming Messages responses.
+- [streaming-messages](streaming-messages): An example of streaming Messages
+  responses, using `StreamAccumulator` to rebuild the final `MessagesResponse`.
+- [tool-loop](tool-loop): End-to-end tool-use demo driven by
+  `run_tool_loop`. The helper handles the call/execute/reply cycle so the
+  example only needs to implement the tool logic.

--- a/examples/streaming-messages/src/main.rs
+++ b/examples/streaming-messages/src/main.rs
@@ -1,70 +1,41 @@
 use std::io::Write;
 
-use anthropic::types::{ContentBlock, ContentBlockDelta, Message, MessagesRequestBuilder, MessagesStreamEvent, Role};
+use anthropic::stream::StreamAccumulator;
+use anthropic::types::{ContentBlockDelta, Message, MessagesRequestBuilder, MessagesStreamEvent};
 use anthropic::Client;
 use dotenvy::dotenv;
 use tokio_stream::StreamExt;
-
-fn extend_messages(messages: &mut Vec<Message>, event: &MessagesStreamEvent) {
-    match event {
-        MessagesStreamEvent::MessageStart { message } => {
-            messages.push(Message { role: message.role, content: message.content.clone() });
-        }
-        MessagesStreamEvent::ContentBlockStart { content_block, .. } => {
-            if let Some(last) = messages.last_mut() {
-                last.content.push(content_block.clone());
-            }
-        }
-        MessagesStreamEvent::ContentBlockDelta { index, delta } => {
-            if let Some(last) = messages.last_mut() {
-                match (last.content.get_mut(*index), delta) {
-                    (Some(ContentBlock::Text { text, .. }), ContentBlockDelta::TextDelta { text: delta }) => {
-                        *text += delta;
-                    }
-                    _ => (),
-                }
-            }
-        }
-        _ => (),
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv().ok();
 
     let client = Client::from_env()?;
-    let mut messages = vec![Message {
-        role: Role::User,
-        content: vec![ContentBlock::text("Stream a short greeting.")],
-    }];
+    let messages = vec![Message::user("Stream a short greeting.")];
 
     let request = MessagesRequestBuilder::new("claude-3-5-sonnet-20240620", messages.clone(), 128).build()?;
 
     println!("\n\nSending messages:\n{messages:#?}\n");
     let mut stream = client.messages_stream(request).await?;
 
-    while let Some(resp) = stream.next().await {
-        match resp {
-            Ok(response) => {
-                extend_messages(&mut messages, &response);
+    // Tee every event into a StreamAccumulator while also printing text
+    // deltas as they arrive. When the stream ends we materialize the final
+    // MessagesResponse — no manual book-keeping required.
+    let mut accumulator = StreamAccumulator::new();
 
-                if let MessagesStreamEvent::ContentBlockDelta {
-                    delta: ContentBlockDelta::TextDelta { text },
-                    ..
-                } = response
-                {
-                    print!("{text}");
-                    std::io::stdout().flush().ok();
-                }
-            }
-            Err(e) => {
-                println!("\n{e}\n");
-            }
+    while let Some(event) = stream.next().await {
+        let event = event?;
+
+        if let MessagesStreamEvent::ContentBlockDelta { delta: ContentBlockDelta::TextDelta { text }, .. } = &event {
+            print!("{text}");
+            std::io::stdout().flush().ok();
         }
+
+        accumulator.push(event)?;
     }
 
-    println!("\n\nNew messages:\n{messages:#?}");
+    let response = accumulator.finish()?;
+    println!("\n\nFinal response:\n{response:#?}");
 
     Ok(())
 }

--- a/examples/streaming-messages/src/main.rs
+++ b/examples/streaming-messages/src/main.rs
@@ -7,7 +7,9 @@ use tokio_stream::StreamExt;
 
 fn extend_messages(messages: &mut Vec<Message>, event: &MessagesStreamEvent) {
     match event {
-        MessagesStreamEvent::MessageStart { message } => messages.push(message.clone()),
+        MessagesStreamEvent::MessageStart { message } => {
+            messages.push(Message { role: message.role, content: message.content.clone() });
+        }
         MessagesStreamEvent::ContentBlockStart { content_block, .. } => {
             if let Some(last) = messages.last_mut() {
                 last.content.push(content_block.clone());
@@ -16,7 +18,7 @@ fn extend_messages(messages: &mut Vec<Message>, event: &MessagesStreamEvent) {
         MessagesStreamEvent::ContentBlockDelta { index, delta } => {
             if let Some(last) = messages.last_mut() {
                 match (last.content.get_mut(*index), delta) {
-                    (Some(ContentBlock::Text { text }), ContentBlockDelta::TextDelta { text: delta }) => {
+                    (Some(ContentBlock::Text { text, .. }), ContentBlockDelta::TextDelta { text: delta }) => {
                         *text += delta;
                     }
                     _ => (),

--- a/examples/tool-loop/Cargo.toml
+++ b/examples/tool-loop/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tool-loop"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anthropic = { path = "../../anthropic" }
+dotenvy = "0.15"
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/tool-loop/src/main.rs
+++ b/examples/tool-loop/src/main.rs
@@ -1,0 +1,61 @@
+//! End-to-end demo of [`anthropic::tool_loop::run_tool_loop`].
+//!
+//! This example defines two "weather" tools, registers them on a Messages
+//! request, and lets the helper drive the whole call/execute/reply cycle.
+
+use anthropic::tool_loop::{run_tool_loop, ToolLoopConfig, ToolOutput};
+use anthropic::types::{Message, MessagesRequestBuilder, Tool, ToolChoice};
+use anthropic::Client;
+use dotenvy::dotenv;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv().ok();
+
+    let client = Client::from_env()?;
+
+    let request = MessagesRequestBuilder::new(
+        "claude-3-5-sonnet-20240620",
+        vec![Message::user(
+            "Compare today's weather in Paris and Rome in one sentence, using the get_weather tool.",
+        )],
+        512,
+    )
+    .tools(vec![Tool::new(
+        "get_weather",
+        "Fetch the current weather for a city by name",
+        json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string", "description": "City name" }
+            },
+            "required": ["city"]
+        }),
+    )])
+    .tool_choice(ToolChoice::Auto)
+    .build()?;
+
+    let response = run_tool_loop(
+        &client,
+        request,
+        |name, input| async move {
+            println!("-> executing tool `{name}` with input {input}");
+            if name != "get_weather" {
+                return Ok(ToolOutput::error(format!("unknown tool: {name}")));
+            }
+            let city = input.get("city").and_then(|v| v.as_str()).unwrap_or("");
+            let result = match city.to_lowercase().as_str() {
+                "paris" => "Paris: 22C and sunny",
+                "rome" => "Rome: 27C and partly cloudy",
+                other => return Ok(ToolOutput::error(format!("unknown city: {other}"))),
+            };
+            Ok(ToolOutput::ok(result))
+        },
+        ToolLoopConfig::default(),
+    )
+    .await?;
+
+    println!("\nFinal answer:\n{}", response.text());
+    Ok(())
+}


### PR DESCRIPTION
Expands the type system to match the modern Messages API surface and adds
the first unit-test suite for the crate.

Milestone: Type system upgrade + unit tests
Changes:
- types.rs: add CacheControl enum with ephemeral/ephemeral_ttl constructors
- types.rs: add cache_control field to Text/Image/Document/ToolUse/ToolResult
  content blocks and to Tool definitions
- types.rs: add ImageSource::Url variant for remote images
- types.rs: add ContentBlock::Document variant with DocumentSource
  (base64/text/url/content) and CitationsConfig
- types.rs: add optional signature field to ContentBlock::Thinking
- types.rs: add constructor helpers on ContentBlock (text, image_base64,
  image_url, document_*, tool_use, tool_result_text/blocks/error, thinking)
  and a fluent with_cache_control method
- types.rs: add Message::user/assistant/new helpers and SystemPrompt
  From<&str>/From<String> conversions plus builder sugar
- types.rs: add ToolChoice::None variant
- types.rs: add ThinkingConfig (Enabled/Disabled) and ServiceTier
  (Auto/StandardOnly) plus matching builder methods on MessagesRequest
- types.rs: add cache_creation/read/service_tier fields to Usage and
  MessageDeltaUsage for prompt caching accounting
- types.rs: add ContentBlockDelta::ThinkingDelta and SignatureDelta for
  extended thinking stream events; switch MessagesStreamEvent::MessageStart
  to carry a MessagesResponse (matches real API shape)
- types.rs: validate non-empty model, non-empty messages, and non-zero
  max_tokens in MessagesRequestBuilder::build
- types.rs: add MessagesResponse accessors text(), first_text(),
  tool_uses(), has_tool_use()
- types.rs: add 30 inline unit tests covering serde roundtrips, builder
  validation, response helpers, and stream event shapes
- examples/streaming-messages: update to new ContentBlock::Text pattern
  (cache_control field) and MessageStart carrying MessagesResponse

Validated: cargo test (30 passed), cargo clippy -D warnings clean,
cargo fmt --all --check clean, all examples build.