### PR TITLE
feat(client): production hardening — tracing, retry overrides, MSRV, supply chain, fuzzing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: cargo doc
         run: cargo doc --workspace --no-deps --all-features
+
+  msrv:
+    # Build and test the crate on the minimum supported Rust version
+    # declared in `anthropic/Cargo.toml` (`package.rust-version`) so that a
+    # PR cannot accidentally introduce a dependency or language feature
+    # that pushes the toolchain forward without us noticing.
+    #
+    # If this job fails, either roll back the offending change or bump
+    # `rust-version` intentionally and document it in CHANGELOG.md.
+    #
+    # This crate does not commit a Cargo.lock (it is a library), so MSRV is
+    # verified against freshly-resolved dependency versions. A transitive
+    # dep release can therefore shift the MSRV independently of this repo —
+    # when that happens, pin the offending dep in Cargo.toml or bump our
+    # own `rust-version`, whichever is less costly to downstream users.
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: |
+          msrv=$(grep '^rust-version' anthropic/Cargo.toml | head -n1 | tr -d ' "' | cut -d= -f2)
+          echo "version=${msrv}" >> "$GITHUB_OUTPUT"
+          echo "MSRV pinned to ${msrv}"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo build (all features)
+        run: cargo build --workspace --all-features
+      - name: cargo test (all features)
+        run: cargo test --workspace --all-features

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,56 @@
+name: Fuzz
+
+# Short fuzz smoke test. Builds every `cargo fuzz` target against the
+# latest nightly and runs each for a few seconds. The goal is to catch
+# immediate regressions (e.g. a new parse path that unwraps on empty
+# input), not to replace a long-running campaign.
+#
+# A nightly schedule picks up new upstream advisories even on quiet
+# weeks; a workflow_dispatch trigger lets anyone run the whole thing
+# manually from the Actions tab.
+
+on:
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "anthropic/src/**"
+      - "fuzz/**"
+      - ".github/workflows/fuzz.yml"
+  pull_request:
+    paths:
+      - "anthropic/src/**"
+      - "fuzz/**"
+      - ".github/workflows/fuzz.yml"
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: cargo fuzz (smoke)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - parse_error
+          - parse_results_jsonl
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install --locked cargo-fuzz
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            fuzz
+      - name: Smoke-run fuzz target
+        working-directory: fuzz
+        # `-max_total_time=30` bounds the smoke run to 30 seconds. Panics
+        # surface as a non-zero exit; no news == good news.
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=30

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,60 @@
+name: Supply Chain
+
+# Supply-chain hardening: runs `cargo audit` (RustSec advisory database) and
+# `cargo deny` (licenses, duplicates, source allowlist) on every PR and push
+# to main, plus on a daily schedule so that newly-disclosed vulnerabilities
+# surface even when the repo is quiet.
+#
+# This workflow is the single failure point that protects us from an
+# advisory showing up in a transitive dependency. It does not build the
+# crate — it only walks the lockfile and Cargo.toml metadata — so it runs
+# quickly enough to block merges without slowing CI materially.
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+  schedule:
+    # Every day at 06:00 UTC. Cron fires even on quiet days so a new CVE
+    # surfaces via a red daily run rather than waiting for the next push.
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: supply-chain-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Required for `rustsec/audit-check` to surface findings as a status check.
+  issues: write
+  checks: write
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run every check category independently so the failure message
+        # points at the exact policy that failed.
+        checks:
+          - advisories
+          - bans
+          - licenses
+          - sources
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}
+          arguments: --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional `tracing` Cargo feature. When enabled, every HTTP call on the
+  transport critical path emits an `anthropic.http` span with `method`,
+  `path`, `status`, `attempts`, and `duration_ms` fields, plus a
+  per-attempt `debug!` event carrying the attempt number, response status,
+  and attempt duration. The dependency and every instrumentation point
+  compile out entirely when the feature is off.
+- Per-call retry policy override via the new `RetryPolicy` type and the
+  `MessagesRequestBuilder::backoff` / `no_retries` / `retry_policy`
+  builder methods (plus the equivalents on `CountTokensRequestBuilder`
+  and `CreateBatchRequest`). Interactive paths can opt out of retries
+  with `.no_retries()`; background workers can stretch the retry budget
+  with `.backoff(ExponentialBackoff { .. })` — all without rebuilding
+  the `Client`.
+- Pinned MSRV of 1.82 via `package.rust-version` in `anthropic/Cargo.toml`
+  and a matching `MSRV` job in `.github/workflows/ci.yml` that reads the
+  version from `Cargo.toml` so it stays in sync automatically.
+- Supply-chain CI: a new `.github/workflows/supply-chain.yml` runs
+  `cargo audit` and `cargo deny` (checking advisories, bans, licenses, and
+  sources) on every PR, every push to main, and on a daily schedule.
+  Policy is configured in a committed `deny.toml`.
+- Fuzz targets for `parse_error` and `parse_results_jsonl` under `fuzz/`,
+  wired to a `Fuzz` GitHub Actions workflow that smoke-runs each target
+  on nightly. Both parsers sit on the transport critical path and consume
+  attacker-controllable bytes, so the harness enforces the
+  "never panic on arbitrary input" contract. A small regression corpus
+  is baked into the library's `__fuzz` test module so the same invariants
+  are checked in regular CI runs.
 - `Client` now derives `Clone` and implements `Debug` with the API key
   redacted, so clients can be safely shared across handlers and printed in
   diagnostic logs without leaking credentials.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ application that talks to `https://api.anthropic.com`.
 
 ## Workspace layout
 
-This is a Cargo workspace with **two** workspaces:
+This is a Cargo workspace with **three** independent workspaces:
 
 ```
 /                           ← top-level workspace (publishes the SDK)
@@ -21,37 +21,57 @@ This is a Cargo workspace with **two** workspaces:
 │   ├── Cargo.toml
 │   ├── README.md           ← also surfaces on crates.io / docs.rs
 │   ├── src/
-│   │   ├── lib.rs          ← public re-exports
+│   │   ├── lib.rs          ← public re-exports + `__fuzz` entry points
 │   │   ├── client.rs       ← Client / ClientBuilder / retries / streaming transport
 │   │   ├── error.rs        ← AnthropicError + ApiError payload
-│   │   ├── types.rs        ← Messages API request / response / content blocks
+│   │   ├── types.rs        ← Messages API request / response / content blocks / RetryPolicy
 │   │   ├── stream.rs       ← StreamAccumulator + collect helpers
 │   │   ├── tool_loop.rs    ← run_tool_loop agentic helper
 │   │   ├── batches.rs      ← Message Batches API
 │   │   ├── count_tokens.rs ← count_tokens endpoint
 │   │   └── models.rs       ← list_models / get_model
 │   └── tests/              ← wiremock-backed integration tests
-└── examples/               ← SECOND workspace, never built by `cargo test` at root
-    ├── Cargo.toml          ← workspace = ["basic-messages", "streaming-messages", "tool-loop"]
-    ├── basic-messages/
-    ├── streaming-messages/
-    └── tool-loop/
+├── examples/               ← SECOND workspace, never built by `cargo test` at root
+│   ├── Cargo.toml          ← workspace = ["basic-messages", "streaming-messages", "tool-loop"]
+│   ├── basic-messages/
+│   ├── streaming-messages/
+│   └── tool-loop/
+├── fuzz/                   ← THIRD workspace — `cargo fuzz` targets (requires nightly)
+│   ├── Cargo.toml          ← excluded from the root workspace so stable builds never pull libfuzzer-sys
+│   └── fuzz_targets/
+│       ├── parse_error.rs
+│       └── parse_results_jsonl.rs
+└── deny.toml               ← cargo-deny policy (advisories, licenses, sources, bans)
 ```
 
-The `examples/` directory is **a separate workspace** so the SDK can be
-published without dragging the example crates along. To build / run an example
-you must `cd examples` first or use `--manifest-path examples/<name>/Cargo.toml`.
+Both `examples/` and `fuzz/` are **separate workspaces** so the SDK can
+be published without dragging the example crates along and so a top-level
+`cargo test` does not try to resolve nightly fuzz dependencies. To build
+an example you must `cd examples` first; to run a fuzz target you must
+`cd fuzz` and use `cargo +nightly fuzz run <target>`.
 
 ## Tech stack
 
-- **Language**: Rust 2021 edition. No MSRV is currently pinned.
+- **Language**: Rust 2021 edition. MSRV pinned to 1.82 via
+  `package.rust-version`; an MSRV job in CI reads that value and builds +
+  tests the workspace on the declared toolchain.
 - **Async runtime**: `tokio` (multi-thread, macros).
 - **HTTP**: `reqwest` 0.12 with `json` + `stream` features.
 - **SSE**: `reqwest-eventsource` 0.6.
 - **TLS**: `rustls` (default) or `native-tls` via Cargo features.
 - **Retries**: `backoff` 0.4 (`ExponentialBackoff` for 429s, honoring `Retry-After`).
+  Per-call overrides live on `RetryPolicy` and are plumbed through the
+  request builders.
+- **Tracing**: optional `tracing` Cargo feature — compiled out entirely
+  when disabled. Spans wrap `execute_bytes` on the transport critical path
+  and carry `method`, `path`, `status`, `attempts`, and `duration_ms`.
 - **Errors**: `thiserror`.
 - **Tests**: `wiremock` 0.6 + `dotenvy` (dev only).
+- **Supply chain**: `cargo audit` + `cargo deny` run on every PR via
+  `.github/workflows/supply-chain.yml`.
+- **Fuzzing**: `fuzz/` sub-crate with `cargo-fuzz` harnesses for
+  `parse_error` and `parse_results_jsonl` (the two parsers on the
+  transport critical path that run on untrusted bytes).
 
 ## Build / test / lint commands
 
@@ -77,6 +97,17 @@ The example workspace is built separately:
 ```bash
 (cd examples && cargo build)
 ```
+
+Fuzz targets live in their own workspace (`fuzz/`) and require nightly
+Rust and `cargo-fuzz`:
+
+```bash
+(cd fuzz && cargo +nightly fuzz run parse_error -- -max_total_time=30)
+(cd fuzz && cargo +nightly fuzz run parse_results_jsonl -- -max_total_time=30)
+```
+
+CI runs a short smoke version of the same commands on every PR via
+`.github/workflows/fuzz.yml`.
 
 ## Conventions
 

--- a/anthropic/Cargo.toml
+++ b/anthropic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "anthropic"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.82"
 license = "MIT"
 homepage = "https://github.com/AbdelStark/anthropic-rs"
 repository = "https://github.com/AbdelStark/anthropic-rs"
@@ -16,6 +17,11 @@ default = ["rustls"]
 rustls = ["reqwest/rustls-tls-native-roots"]
 # Enable native-tls for TLS support
 native-tls = ["reqwest/native-tls"]
+# Emit structured `tracing` spans around every HTTP call on the transport
+# critical path. The spans carry `method`, `path`, `status`, `attempt`, and
+# `duration_ms` fields. When disabled, the `tracing` dependency is not built
+# and every instrumentation point compiles to a no-op.
+tracing = ["dep:tracing"]
 
 [dependencies]
 backoff = { version = "0.4", features = ["tokio"], default-features = false }
@@ -27,7 +33,14 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["std", "attributes"], optional = true }
 
 [dev-dependencies]
 dotenvy = "0.15"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 wiremock = "0.6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/anthropic/README.md
+++ b/anthropic/README.md
@@ -326,6 +326,27 @@ let _list = client.list_batches(&ListBatchesParams::new().limit(10)).await?;
 | `StreamAccumulator` / `anthropic::stream::collect` | `Result<MessagesResponse, AnthropicError>` | Folds a live SSE stream into a full response. |
 | `run_tool_loop(&client, request, executor, config)` | `Result<MessagesResponse, AnthropicError>` | Agentic call/execute/reply loop with iteration budget. |
 | `ClientBuilder::backoff(...)` | `ClientBuilder` | Customizes retry behavior for cloneable requests. |
+| `MessagesRequestBuilder::backoff(...)` / `.no_retries()` / `.retry_policy(...)` | `MessagesRequestBuilder` | Per-call retry override — opt out of retries on interactive paths or stretch them for background workers without rebuilding the client. Also available on `CountTokensRequestBuilder` and `CreateBatchRequest`. |
+
+### Cargo features
+
+| Feature | Default | What it does |
+| --- | --- | --- |
+| `rustls` | ✅ | TLS via `rustls` + native root certs (pulled from `reqwest`). |
+| `native-tls` | | Swap to the system-native TLS stack. |
+| `tracing` | | Emit structured `tracing` spans around every HTTP call on the transport critical path (`anthropic.http`), carrying `method`, `path`, `status`, `attempts`, and `duration_ms` fields, plus per-attempt debug events. Compiled out entirely when the feature is off. |
+
+Enable tracing in your `Cargo.toml`:
+
+```toml
+[dependencies]
+anthropic = { version = "0.1", features = ["tracing"] }
+tracing-subscriber = "0.3"
+```
+
+Then install any `tracing` subscriber at startup (for example
+`tracing_subscriber::fmt::init()`), and every `/v1/*` call will show up
+as an `anthropic.http` span with the fields listed above.
 
 ## Deployment / Integration
 

--- a/anthropic/src/batches.rs
+++ b/anthropic/src/batches.rs
@@ -4,10 +4,11 @@
 //! operation and poll for results asynchronously. Each request in the batch is
 //! identified by a `custom_id` that the caller chooses.
 
+use backoff::ExponentialBackoff;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AnthropicError;
-use crate::types::{MessagesRequest, MessagesResponse};
+use crate::types::{MessagesRequest, MessagesResponse, RetryPolicy};
 
 /// Individual request entry submitted as part of a batch.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -26,11 +27,14 @@ impl BatchRequest {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct CreateBatchRequest {
     pub requests: Vec<BatchRequest>,
+    /// Per-request retry policy. Carried in memory only; never serialized.
+    #[serde(skip, default)]
+    pub retry_policy: RetryPolicy,
 }
 
 impl CreateBatchRequest {
     pub fn new(requests: Vec<BatchRequest>) -> Self {
-        Self { requests }
+        Self { requests, retry_policy: RetryPolicy::default() }
     }
 
     /// Validate that a batch has at least one request before sending.
@@ -39,6 +43,24 @@ impl CreateBatchRequest {
             return Err(AnthropicError::InvalidRequest("batch must contain at least one request".into()));
         }
         Ok(())
+    }
+
+    /// Override the retry policy for this batch submission. See [`RetryPolicy`].
+    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// Use a caller-supplied [`ExponentialBackoff`] for this submission.
+    pub fn backoff(mut self, backoff: ExponentialBackoff) -> Self {
+        self.retry_policy = RetryPolicy::custom(backoff);
+        self
+    }
+
+    /// Disable retries for this batch submission.
+    pub fn no_retries(mut self) -> Self {
+        self.retry_policy = RetryPolicy::none();
+        self
     }
 }
 

--- a/anthropic/src/client.rs
+++ b/anthropic/src/client.rs
@@ -1,7 +1,9 @@
 use std::pin::Pin;
-use std::time::Duration;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use backoff::ExponentialBackoff;
+pub use backoff::ExponentialBackoff;
 use futures_util::StreamExt;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, USER_AGENT};
 use reqwest_eventsource::{Event, EventSource, RequestBuilderExt};
@@ -15,7 +17,7 @@ use crate::batches::{
 use crate::count_tokens::{CountTokensRequest, CountTokensResponse};
 use crate::error::{AnthropicError, ErrorResponse};
 use crate::models::{ListModelsParams, Model, ModelList};
-use crate::types::{MessagesRequest, MessagesResponse, MessagesStreamEvent};
+use crate::types::{MessagesRequest, MessagesResponse, MessagesStreamEvent, RetryPolicy};
 
 const DEFAULT_API_BASE: &str = "https://api.anthropic.com";
 const DEFAULT_API_VERSION: &str = "2023-06-01";
@@ -203,7 +205,8 @@ impl Client {
             return Err(AnthropicError::InvalidRequest("stream=true requests must use messages_stream".into()));
         }
         request.stream = None;
-        self.post("/v1/messages", &request).await
+        let retry = self.resolve_retry(&request.retry_policy);
+        self.post("/v1/messages", &request, retry).await
     }
 
     pub async fn messages_stream(
@@ -217,56 +220,78 @@ impl Client {
     /// `POST /v1/messages/count_tokens` — compute the input-token cost of a
     /// Messages request without actually generating a response.
     pub async fn count_tokens(&self, request: CountTokensRequest) -> Result<CountTokensResponse, AnthropicError> {
-        self.post("/v1/messages/count_tokens", &request).await
+        let retry = self.resolve_retry(&request.retry_policy);
+        self.post("/v1/messages/count_tokens", &request, retry).await
     }
 
     /// `GET /v1/models` — list every model available to the authenticated key.
     pub async fn list_models(&self, params: &ListModelsParams) -> Result<ModelList, AnthropicError> {
-        self.get("/v1/models", &params.as_query()).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.get("/v1/models", &params.as_query(), retry).await
     }
 
     /// `GET /v1/models/{model_id}` — fetch metadata about a single model.
     pub async fn get_model(&self, model_id: &str) -> Result<Model, AnthropicError> {
         let path = format!("/v1/models/{}", model_id);
-        self.get::<Model>(&path, &[]).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.get::<Model>(&path, &[], retry).await
     }
 
     /// `POST /v1/messages/batches` — submit a new batch of Messages requests.
     pub async fn create_batch(&self, request: CreateBatchRequest) -> Result<MessageBatch, AnthropicError> {
         request.validate()?;
-        self.post("/v1/messages/batches", &request).await
+        let retry = self.resolve_retry(&request.retry_policy);
+        self.post("/v1/messages/batches", &request, retry).await
     }
 
     /// `GET /v1/messages/batches` — list batches submitted by this workspace.
     pub async fn list_batches(&self, params: &ListBatchesParams) -> Result<MessageBatchList, AnthropicError> {
-        self.get("/v1/messages/batches", &params.as_query()).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.get("/v1/messages/batches", &params.as_query(), retry).await
     }
 
     /// `GET /v1/messages/batches/{id}` — fetch current metadata for a batch.
     pub async fn get_batch(&self, batch_id: &str) -> Result<MessageBatch, AnthropicError> {
         let path = format!("/v1/messages/batches/{}", batch_id);
-        self.get::<MessageBatch>(&path, &[]).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.get::<MessageBatch>(&path, &[], retry).await
     }
 
     /// `POST /v1/messages/batches/{id}/cancel` — request cancellation of a
     /// batch. Already-completed requests remain available in the results.
     pub async fn cancel_batch(&self, batch_id: &str) -> Result<MessageBatch, AnthropicError> {
         let path = format!("/v1/messages/batches/{}/cancel", batch_id);
-        self.post_empty::<MessageBatch>(&path).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.post_empty::<MessageBatch>(&path, retry).await
     }
 
     /// `DELETE /v1/messages/batches/{id}` — permanently delete a batch.
     pub async fn delete_batch(&self, batch_id: &str) -> Result<serde_json::Value, AnthropicError> {
         let path = format!("/v1/messages/batches/{}", batch_id);
-        self.delete::<serde_json::Value>(&path).await
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        self.delete::<serde_json::Value>(&path, retry).await
     }
 
     /// `GET /v1/messages/batches/{id}/results` — download and parse the
     /// JSON-Lines results file for a completed batch.
     pub async fn get_batch_results(&self, batch_id: &str) -> Result<Vec<BatchResultItem>, AnthropicError> {
         let path = format!("/v1/messages/batches/{}/results", batch_id);
-        let body = self.get_raw(&path).await?;
+        let retry = self.resolve_retry(&RetryPolicy::default());
+        let body = self.get_raw(&path, retry).await?;
         parse_results_jsonl(&body)
+    }
+
+    /// Resolve an in-memory [`RetryPolicy`] to an optional [`ExponentialBackoff`].
+    ///
+    /// Returns `None` when retries should be disabled for this call. Returns
+    /// `Some(backoff)` when retries should run, either with the client-wide
+    /// default or the per-call override.
+    fn resolve_retry(&self, policy: &RetryPolicy) -> Option<ExponentialBackoff> {
+        match policy.kind() {
+            crate::types::RetryPolicyKind::ClientDefault => Some(self.backoff.clone()),
+            crate::types::RetryPolicyKind::Disabled => None,
+            crate::types::RetryPolicyKind::Custom(bo) => Some(bo.clone()),
+        }
     }
 
     fn headers(&self) -> Result<HeaderMap, AnthropicError> {
@@ -282,7 +307,7 @@ impl Client {
         Ok(headers)
     }
 
-    async fn post<I, O>(&self, path: &str, request: &I) -> Result<O, AnthropicError>
+    async fn post<I, O>(&self, path: &str, request: &I, retry: Option<ExponentialBackoff>) -> Result<O, AnthropicError>
     where
         I: Serialize + ?Sized,
         O: DeserializeOwned,
@@ -290,38 +315,43 @@ impl Client {
         let request =
             self.http_client.post(format!("{}{path}", self.api_base)).headers(self.headers()?).json(request).build()?;
 
-        self.execute(request).await
+        self.execute(request, retry).await
     }
 
-    async fn get<O>(&self, path: &str, query: &[(&str, String)]) -> Result<O, AnthropicError>
+    async fn get<O>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+        retry: Option<ExponentialBackoff>,
+    ) -> Result<O, AnthropicError>
     where
         O: DeserializeOwned,
     {
         let request =
             self.http_client.get(format!("{}{path}", self.api_base)).headers(self.headers()?).query(query).build()?;
 
-        self.execute(request).await
+        self.execute(request, retry).await
     }
 
-    async fn get_raw(&self, path: &str) -> Result<String, AnthropicError> {
+    async fn get_raw(&self, path: &str, retry: Option<ExponentialBackoff>) -> Result<String, AnthropicError> {
         let request = self.http_client.get(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
-        self.execute_raw(request).await
+        self.execute_raw(request, retry).await
     }
 
-    async fn post_empty<O>(&self, path: &str) -> Result<O, AnthropicError>
+    async fn post_empty<O>(&self, path: &str, retry: Option<ExponentialBackoff>) -> Result<O, AnthropicError>
     where
         O: DeserializeOwned,
     {
         let request = self.http_client.post(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
-        self.execute(request).await
+        self.execute(request, retry).await
     }
 
-    async fn delete<O>(&self, path: &str) -> Result<O, AnthropicError>
+    async fn delete<O>(&self, path: &str, retry: Option<ExponentialBackoff>) -> Result<O, AnthropicError>
     where
         O: DeserializeOwned,
     {
         let request = self.http_client.delete(format!("{}{path}", self.api_base)).headers(self.headers()?).build()?;
-        self.execute(request).await
+        self.execute(request, retry).await
     }
 
     async fn post_stream<I>(
@@ -343,60 +373,188 @@ impl Client {
         Ok(stream(event_source).await)
     }
 
-    async fn execute<O>(&self, request: reqwest::Request) -> Result<O, AnthropicError>
+    async fn execute<O>(
+        &self,
+        request: reqwest::Request,
+        retry: Option<ExponentialBackoff>,
+    ) -> Result<O, AnthropicError>
     where
         O: DeserializeOwned,
     {
-        let bytes = self.execute_bytes(request).await?;
+        let bytes = self.execute_bytes(request, retry).await?;
         serde_json::from_slice::<O>(&bytes).map_err(AnthropicError::Deserialize)
     }
 
-    async fn execute_raw(&self, request: reqwest::Request) -> Result<String, AnthropicError> {
-        let bytes = self.execute_bytes(request).await?;
+    async fn execute_raw(
+        &self,
+        request: reqwest::Request,
+        retry: Option<ExponentialBackoff>,
+    ) -> Result<String, AnthropicError> {
+        let bytes = self.execute_bytes(request, retry).await?;
         Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     /// Send a request with retry-on-429, returning the raw success body.
     ///
     /// All response parsing happens in callers; this method only deals with
-    /// transport, retries, and HTTP-level error mapping.
-    async fn execute_bytes(&self, request: reqwest::Request) -> Result<Vec<u8>, AnthropicError> {
-        let client = self.http_client.clone();
+    /// transport, retries, and HTTP-level error mapping. When the `tracing`
+    /// Cargo feature is enabled, each call emits an `anthropic.http` span with
+    /// `method`, `path`, `attempts`, `status`, and `duration_ms` fields, plus
+    /// a per-attempt event carrying the attempt number, response status, and
+    /// attempt duration.
+    async fn execute_bytes(
+        &self,
+        request: reqwest::Request,
+        retry: Option<ExponentialBackoff>,
+    ) -> Result<Vec<u8>, AnthropicError> {
+        // Snapshot the method + path before the request is moved into the
+        // retry closure — they're used by the tracing span as well as any
+        // per-attempt events below.
+        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+        let method = request.method().clone();
+        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+        let path = request.url().path().to_string();
 
-        // `reqwest::Request` cannot be cloned when its body is a stream. In
-        // that case we cannot safely retry — fall back to a single attempt.
-        let Some(retryable) = request.try_clone() else {
-            let response = client.execute(request).await?;
-            return process_bytes(response).await;
+        #[cfg(feature = "tracing")]
+        let span = tracing::info_span!(
+            "anthropic.http",
+            method = %method,
+            path = %path,
+            attempts = tracing::field::Empty,
+            status = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+        );
+        #[cfg(feature = "tracing")]
+        let _entered = span.enter();
+
+        #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+        let overall_started = Instant::now();
+        let attempt_counter = Arc::new(AtomicU32::new(0));
+
+        let result = match retry {
+            // No retries — fail on the first non-success response.
+            None => execute_once(self.http_client.clone(), request, &attempt_counter).await,
+            Some(backoff) => {
+                // `reqwest::Request` cannot be cloned when its body is a
+                // stream. Fall back to a single attempt in that case — there's
+                // no safe way to retry a consumed body.
+                match request.try_clone() {
+                    None => execute_once(self.http_client.clone(), request, &attempt_counter).await,
+                    Some(retryable) => {
+                        let client = self.http_client.clone();
+                        let attempts = attempt_counter.clone();
+                        backoff::future::retry(backoff, move || {
+                            let client = client.clone();
+                            let attempts = attempts.clone();
+                            let cloned = retryable.try_clone().ok_or_else(|| {
+                                backoff::Error::Permanent(AnthropicError::InvalidRequest(
+                                    "request could not be cloned".into(),
+                                ))
+                            });
+                            async move {
+                                let request = cloned?;
+                                #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+                                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                                #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+                                let attempt_started = Instant::now();
+
+                                let response = client
+                                    .execute(request)
+                                    .await
+                                    .map_err(AnthropicError::Http)
+                                    .map_err(backoff::Error::Permanent)?;
+
+                                let status = response.status();
+                                let retry_after =
+                                    parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER));
+                                let bytes = response
+                                    .bytes()
+                                    .await
+                                    .map_err(AnthropicError::Http)
+                                    .map_err(backoff::Error::Permanent)?;
+
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(
+                                    target: "anthropic::http",
+                                    attempt,
+                                    status = status.as_u16(),
+                                    duration_ms = attempt_started.elapsed().as_millis() as u64,
+                                    "anthropic.http.attempt"
+                                );
+
+                                if !status.is_success() {
+                                    let error = parse_error(status.as_u16(), bytes.as_ref());
+                                    if status.as_u16() == 429 {
+                                        return Err(backoff::Error::Transient { err: error, retry_after });
+                                    }
+                                    return Err(backoff::Error::Permanent(error));
+                                }
+
+                                Ok(bytes.to_vec())
+                            }
+                        })
+                        .await
+                    }
+                }
+            }
         };
 
-        backoff::future::retry(self.backoff.clone(), || {
-            let request = retryable.try_clone().ok_or_else(|| {
-                backoff::Error::Permanent(AnthropicError::InvalidRequest("request could not be cloned".into()))
-            });
-            let client = client.clone();
-            async move {
-                let request = request?;
-                let response =
-                    client.execute(request).await.map_err(AnthropicError::Http).map_err(backoff::Error::Permanent)?;
-
-                let status = response.status();
-                let retry_after = parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER));
-                let bytes = response.bytes().await.map_err(AnthropicError::Http).map_err(backoff::Error::Permanent)?;
-
-                if !status.is_success() {
-                    let error = parse_error(status.as_u16(), bytes.as_ref());
-                    if status.as_u16() == 429 {
-                        return Err(backoff::Error::Transient { err: error, retry_after });
-                    }
-                    return Err(backoff::Error::Permanent(error));
+        #[cfg(feature = "tracing")]
+        {
+            let attempts = attempt_counter.load(Ordering::SeqCst);
+            span.record("attempts", attempts);
+            span.record("duration_ms", overall_started.elapsed().as_millis() as u64);
+            match &result {
+                Ok(_) => {
+                    span.record("status", 200u16);
                 }
-
-                Ok(bytes.to_vec())
+                Err(AnthropicError::Api(api)) => {
+                    tracing::warn!(
+                        target: "anthropic::http",
+                        error_type = %api.error_type,
+                        message = %api.message,
+                        "anthropic api error"
+                    );
+                }
+                Err(AnthropicError::UnexpectedResponse { status, .. }) => {
+                    span.record("status", *status);
+                }
+                Err(_) => {}
             }
-        })
-        .await
+        }
+
+        result
     }
+}
+
+/// Execute a request exactly once (no retries), incrementing the attempt
+/// counter and, when tracing is enabled, emitting a per-attempt event.
+async fn execute_once(
+    client: reqwest::Client,
+    request: reqwest::Request,
+    attempts: &AtomicU32,
+) -> Result<Vec<u8>, AnthropicError> {
+    #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+    let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+    #[cfg_attr(not(feature = "tracing"), allow(unused_variables))]
+    let started = Instant::now();
+    let response = client.execute(request).await?;
+    let status = response.status();
+    let bytes = response.bytes().await?;
+
+    #[cfg(feature = "tracing")]
+    tracing::debug!(
+        target: "anthropic::http",
+        attempt,
+        status = status.as_u16(),
+        duration_ms = started.elapsed().as_millis() as u64,
+        "anthropic.http.attempt"
+    );
+
+    if !status.is_success() {
+        return Err(parse_error(status.as_u16(), bytes.as_ref()));
+    }
+    Ok(bytes.to_vec())
 }
 
 /// Parse a `Retry-After` header value into a [`Duration`].
@@ -415,18 +573,9 @@ fn parse_retry_after(header: Option<&reqwest::header::HeaderValue>) -> Option<Du
     Some(Duration::from_secs(seconds))
 }
 
-async fn process_bytes(response: reqwest::Response) -> Result<Vec<u8>, AnthropicError> {
-    let status = response.status();
-    let bytes = response.bytes().await?;
-    if !status.is_success() {
-        return Err(parse_error(status.as_u16(), bytes.as_ref()));
-    }
-    Ok(bytes.to_vec())
-}
-
 pub type MessagesResponseStream = Pin<Box<dyn Stream<Item = Result<MessagesStreamEvent, AnthropicError>> + Send>>;
 
-fn parse_error(status: u16, bytes: &[u8]) -> AnthropicError {
+pub(crate) fn parse_error(status: u16, bytes: &[u8]) -> AnthropicError {
     if let Ok(error) = serde_json::from_slice::<ErrorResponse>(bytes) {
         return AnthropicError::Api(error.error);
     }

--- a/anthropic/src/count_tokens.rs
+++ b/anthropic/src/count_tokens.rs
@@ -3,10 +3,11 @@
 //! Lets callers pre-compute the input-token cost of a Messages request without
 //! actually generating a response.
 
+use backoff::ExponentialBackoff;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AnthropicError;
-use crate::types::{Message, MessagesRequest, SystemPrompt, ThinkingConfig, Tool, ToolChoice};
+use crate::types::{Message, MessagesRequest, RetryPolicy, SystemPrompt, ThinkingConfig, Tool, ToolChoice};
 
 /// Request payload for `POST /v1/messages/count_tokens`.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -21,13 +22,17 @@ pub struct CountTokensRequest {
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ThinkingConfig>,
+    /// Per-request retry policy. Carried in memory only; never serialized.
+    #[serde(skip, default)]
+    pub retry_policy: RetryPolicy,
 }
 
 impl CountTokensRequest {
     /// Build a count-tokens request from an existing [`MessagesRequest`].
     ///
     /// Fields that don't affect token counting (max_tokens, temperature, etc.)
-    /// are dropped.
+    /// are dropped. The source request's retry policy is propagated so the
+    /// count-tokens call inherits the same retry behavior.
     pub fn from_messages_request(request: &MessagesRequest) -> Self {
         Self {
             model: request.model.clone(),
@@ -36,6 +41,7 @@ impl CountTokensRequest {
             tools: request.tools.clone(),
             tool_choice: request.tool_choice.clone(),
             thinking: request.thinking.clone(),
+            retry_policy: request.retry_policy.clone(),
         }
     }
 }
@@ -49,6 +55,7 @@ pub struct CountTokensRequestBuilder {
     tools: Option<Vec<Tool>>,
     tool_choice: Option<ToolChoice>,
     thinking: Option<ThinkingConfig>,
+    retry_policy: RetryPolicy,
 }
 
 impl CountTokensRequestBuilder {
@@ -76,6 +83,24 @@ impl CountTokensRequestBuilder {
         self
     }
 
+    /// Override the retry policy for this request. See [`RetryPolicy`].
+    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// Send this request with a caller-supplied [`ExponentialBackoff`].
+    pub fn backoff(mut self, backoff: ExponentialBackoff) -> Self {
+        self.retry_policy = RetryPolicy::custom(backoff);
+        self
+    }
+
+    /// Disable retries for this request.
+    pub fn no_retries(mut self) -> Self {
+        self.retry_policy = RetryPolicy::none();
+        self
+    }
+
     pub fn build(self) -> Result<CountTokensRequest, AnthropicError> {
         let model = self.model.ok_or_else(|| AnthropicError::InvalidRequest("model is required".into()))?;
         if model.is_empty() {
@@ -92,6 +117,7 @@ impl CountTokensRequestBuilder {
             tools: self.tools,
             tool_choice: self.tool_choice,
             thinking: self.thinking,
+            retry_policy: self.retry_policy,
         })
     }
 }

--- a/anthropic/src/lib.rs
+++ b/anthropic/src/lib.rs
@@ -42,6 +42,15 @@
 //! - Prompt-caching (`CacheControl`), extended thinking (`ThinkingConfig`),
 //!   service tier, image / document blocks, and all other modern request
 //!   fields are supported on [`types::MessagesRequestBuilder`].
+//! - Per-call retry override via [`RetryPolicy`] —
+//!   `MessagesRequestBuilder::backoff`, `no_retries`, and `retry_policy`
+//!   let individual calls opt out of retries on interactive paths or
+//!   stretch them for background workers without rebuilding the client.
+//! - Optional `tracing` Cargo feature — enables structured
+//!   `anthropic.http` spans around every HTTP call on the transport
+//!   critical path, with `method`, `path`, `status`, `attempts`, and
+//!   `duration_ms` fields plus per-attempt events. The feature compiles
+//!   out entirely when disabled.
 
 pub mod batches;
 pub mod client;
@@ -56,9 +65,86 @@ pub use batches::{
     BatchProcessingStatus, BatchRequest, BatchRequestCounts, BatchRequestResult, BatchResultItem, CreateBatchRequest,
     ListBatchesParams, MessageBatch, MessageBatchList,
 };
-pub use client::{Client, ClientBuilder};
+pub use client::{Client, ClientBuilder, ExponentialBackoff};
 pub use count_tokens::{CountTokensRequest, CountTokensRequestBuilder, CountTokensResponse};
 pub use error::{AnthropicError, ApiError};
 pub use models::{ListModelsParams, Model, ModelList};
 pub use stream::{collect, collect_stream, StreamAccumulator};
 pub use tool_loop::{run_tool_loop, ToolLoopConfig, ToolOutput};
+pub use types::RetryPolicy;
+
+/// Fuzzing entry points for harnesses under `fuzz/`.
+///
+/// These functions wrap internal parsers that run on attacker-controllable
+/// bytes from the network (error bodies and JSON-Lines batch results). They
+/// are not part of the stable public API — treat everything under this
+/// module as an implementation detail, subject to change at any time — but
+/// they need to be reachable from a sibling fuzz crate that can only see
+/// `pub` items.
+#[doc(hidden)]
+pub mod __fuzz {
+    /// Feed arbitrary bytes through the internal error-body parser the way
+    /// `execute_bytes` does on a non-success response. The function must
+    /// never panic and must always produce an `AnthropicError`.
+    pub fn parse_error(status: u16, bytes: &[u8]) -> crate::AnthropicError {
+        crate::client::parse_error(status, bytes)
+    }
+
+    /// Feed arbitrary bytes (as UTF-8) through the batch results JSONL
+    /// parser. Invalid UTF-8 is silently replaced before parsing, matching
+    /// how the HTTP transport path handles response bodies. The function
+    /// must never panic — it can only succeed or return an
+    /// `AnthropicError::InvalidRequest`.
+    pub fn parse_results_jsonl(bytes: &[u8]) -> Result<Vec<crate::BatchResultItem>, crate::AnthropicError> {
+        // JSONL is text-oriented. Mirror the lossy conversion the live
+        // transport does so the fuzz harness can drive the parser with
+        // arbitrary byte sequences without immediately bailing on non-UTF-8.
+        let text = String::from_utf8_lossy(bytes);
+        crate::batches::parse_results_jsonl(text.as_ref())
+    }
+
+    #[cfg(test)]
+    mod regression_tests {
+        use super::*;
+
+        /// Regression corpus for `parse_error` — crash inputs found by the
+        /// fuzz harness go here as permanent smoke tests.
+        #[test]
+        fn parse_error_handles_crash_corpus() {
+            // Empty body should fall back to UnexpectedResponse.
+            let _ = parse_error(0, &[]);
+            // Invalid UTF-8.
+            let _ = parse_error(500, &[0xff, 0xfe, 0xfd]);
+            // Truncated JSON.
+            let _ = parse_error(400, b"{\"error\":");
+            // Valid structure, unexpected shape.
+            let _ = parse_error(503, b"{\"unexpected\":true}");
+            // Deeply nested JSON should not blow the stack.
+            let mut nested = String::from("{\"a\":");
+            for _ in 0..256 {
+                nested.push_str("{\"a\":");
+            }
+            nested.push('1');
+            for _ in 0..=256 {
+                nested.push('}');
+            }
+            let _ = parse_error(400, nested.as_bytes());
+        }
+
+        /// Regression corpus for `parse_results_jsonl`.
+        #[test]
+        fn parse_results_jsonl_handles_crash_corpus() {
+            // Empty input must succeed with zero items.
+            assert_eq!(parse_results_jsonl(&[]).unwrap().len(), 0);
+            // Only blank lines.
+            assert_eq!(parse_results_jsonl(b"\n\n\n").unwrap().len(), 0);
+            // Garbage bytes — should return an error, never panic.
+            let _ = parse_results_jsonl(&[0xff, 0xfe, 0xfd, b'\n']);
+            // Single malformed line.
+            let _ = parse_results_jsonl(b"not json\n");
+            // Enormous (by test standards) input with repeated malformed lines.
+            let body = "not json\n".repeat(1024);
+            let _ = parse_results_jsonl(body.as_bytes());
+        }
+    }
+}

--- a/anthropic/src/types.rs
+++ b/anthropic/src/types.rs
@@ -1,8 +1,115 @@
 //! Types for Anthropic's Messages API.
 
+use backoff::ExponentialBackoff;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AnthropicError;
+
+/// Per-request retry policy override.
+///
+/// By default every outgoing request inherits the [`ExponentialBackoff`]
+/// configured on the [`Client`](crate::Client), which retries on 429 responses
+/// up to the backoff's `max_elapsed_time`. Individual requests can opt out
+/// (for interactive paths that should fail fast) or supply a custom backoff
+/// (for background workers that should retry for longer).
+///
+/// Use this through the request builders:
+///
+/// ```no_run
+/// use anthropic::types::{Message, MessagesRequestBuilder, RetryPolicy};
+/// use std::time::Duration;
+///
+/// # fn example() -> Result<(), anthropic::AnthropicError> {
+/// // Fail fast on 429: no retries at all.
+/// let interactive = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 128)
+///     .no_retries()
+///     .build()?;
+///
+/// // Long-running worker: retry for up to an hour.
+/// let mut backoff = backoff::ExponentialBackoff::default();
+/// backoff.max_elapsed_time = Some(Duration::from_secs(3600));
+/// let worker = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 128)
+///     .backoff(backoff)
+///     .build()?;
+/// # let _ = (interactive, worker);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// `RetryPolicy` carries transport state only. It is intentionally excluded
+/// from structural equality and is never serialized onto the wire.
+#[derive(Clone, Default)]
+pub struct RetryPolicy {
+    kind: RetryPolicyKind,
+}
+
+#[derive(Clone, Default)]
+pub(crate) enum RetryPolicyKind {
+    /// Inherit the client-wide backoff configuration.
+    #[default]
+    ClientDefault,
+    /// Disable retries entirely: fail on the first non-success response.
+    Disabled,
+    /// Use a caller-supplied backoff for this request only.
+    Custom(ExponentialBackoff),
+}
+
+impl RetryPolicy {
+    /// Use the client's configured retry policy (the default).
+    pub fn client_default() -> Self {
+        Self { kind: RetryPolicyKind::ClientDefault }
+    }
+
+    /// Disable retries entirely for this request.
+    ///
+    /// The call will fail on the first non-success HTTP response, including
+    /// 429 rate-limit responses. Pair this with interactive request paths
+    /// where latency matters more than eventual success.
+    pub fn none() -> Self {
+        Self { kind: RetryPolicyKind::Disabled }
+    }
+
+    /// Use a caller-supplied [`ExponentialBackoff`] for this request.
+    pub fn custom(backoff: ExponentialBackoff) -> Self {
+        Self { kind: RetryPolicyKind::Custom(backoff) }
+    }
+
+    /// Returns `true` if this policy disables retries.
+    pub fn is_disabled(&self) -> bool {
+        matches!(self.kind, RetryPolicyKind::Disabled)
+    }
+
+    /// Returns `true` if this policy defers to the client's configuration.
+    pub fn is_client_default(&self) -> bool {
+        matches!(self.kind, RetryPolicyKind::ClientDefault)
+    }
+
+    pub(crate) fn kind(&self) -> &RetryPolicyKind {
+        &self.kind
+    }
+}
+
+impl std::fmt::Debug for RetryPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            RetryPolicyKind::ClientDefault => f.write_str("RetryPolicy::ClientDefault"),
+            RetryPolicyKind::Disabled => f.write_str("RetryPolicy::Disabled"),
+            RetryPolicyKind::Custom(_) => f.write_str("RetryPolicy::Custom(..)"),
+        }
+    }
+}
+
+// `ExponentialBackoff` is opaque and does not implement `PartialEq`; two
+// requests with different backoff shapes still round-trip identically on the
+// wire, so excluding retry policy from struct equality keeps
+// `#[derive(PartialEq)]` meaningful for the user-facing request types.
+impl PartialEq for RetryPolicy {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for RetryPolicy {}
 
 /// Role a message belongs to in a conversation.
 #[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -384,6 +491,9 @@ pub struct MessagesRequest {
     pub thinking: Option<ThinkingConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<ServiceTier>,
+    /// Per-request retry policy. Carried in memory only; never serialized.
+    #[serde(skip, default)]
+    pub retry_policy: RetryPolicy,
 }
 
 #[derive(Debug, Default)]
@@ -402,6 +512,7 @@ pub struct MessagesRequestBuilder {
     tool_choice: Option<ToolChoice>,
     thinking: Option<ThinkingConfig>,
     service_tier: Option<ServiceTier>,
+    retry_policy: RetryPolicy,
 }
 
 impl MessagesRequestBuilder {
@@ -479,6 +590,37 @@ impl MessagesRequestBuilder {
         self
     }
 
+    /// Override the retry policy for this request.
+    ///
+    /// See [`RetryPolicy`] for the available variants. By default, requests
+    /// inherit the client-wide [`backoff::ExponentialBackoff`] configured on
+    /// [`ClientBuilder::backoff`](crate::ClientBuilder::backoff).
+    pub fn retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// Send this request with a caller-supplied [`ExponentialBackoff`].
+    ///
+    /// Equivalent to `.retry_policy(RetryPolicy::custom(backoff))`. Use this
+    /// to stretch (or tighten) retries on a single call without rebuilding
+    /// the [`Client`](crate::Client).
+    pub fn backoff(mut self, backoff: ExponentialBackoff) -> Self {
+        self.retry_policy = RetryPolicy::custom(backoff);
+        self
+    }
+
+    /// Disable retries for this request.
+    ///
+    /// Equivalent to `.retry_policy(RetryPolicy::none())`. The call will fail
+    /// on the first non-success HTTP response — including 429 rate-limit
+    /// responses — which is the correct behavior for interactive paths where
+    /// latency matters more than eventual success.
+    pub fn no_retries(mut self) -> Self {
+        self.retry_policy = RetryPolicy::none();
+        self
+    }
+
     pub fn build(self) -> Result<MessagesRequest, AnthropicError> {
         let model = self.model.ok_or_else(|| AnthropicError::InvalidRequest("model is required".into()))?;
         if model.is_empty() {
@@ -524,6 +666,7 @@ impl MessagesRequestBuilder {
             tool_choice: self.tool_choice,
             thinking: self.thinking,
             service_tier: self.service_tier,
+            retry_policy: self.retry_policy,
         })
     }
 }
@@ -898,6 +1041,53 @@ mod tests {
         assert!(!obj.contains_key("temperature"));
         assert!(!obj.contains_key("thinking"));
         assert!(!obj.contains_key("service_tier"));
+        // `retry_policy` is an in-memory transport setting — it must not leak
+        // onto the wire under any circumstance.
+        assert!(!obj.contains_key("retry_policy"));
+    }
+
+    #[test]
+    fn retry_policy_defaults_to_client_default() {
+        let policy = RetryPolicy::default();
+        assert!(policy.is_client_default());
+        assert!(!policy.is_disabled());
+    }
+
+    #[test]
+    fn retry_policy_none_is_disabled() {
+        let policy = RetryPolicy::none();
+        assert!(policy.is_disabled());
+        assert!(!policy.is_client_default());
+    }
+
+    #[test]
+    fn retry_policy_custom_reports_neither_default_nor_disabled() {
+        let policy = RetryPolicy::custom(ExponentialBackoff::default());
+        assert!(!policy.is_client_default());
+        assert!(!policy.is_disabled());
+    }
+
+    #[test]
+    fn retry_policy_is_excluded_from_struct_equality() {
+        // Two otherwise-identical requests differing only in retry policy
+        // compare equal — retry policy is transport state, not part of the
+        // semantic request payload.
+        let base = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10).build().unwrap();
+        let no_retries = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10).no_retries().build().unwrap();
+        assert_eq!(base, no_retries);
+    }
+
+    #[test]
+    fn messages_request_builder_sets_retry_policy() {
+        let req = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10).no_retries().build().unwrap();
+        assert!(req.retry_policy.is_disabled());
+
+        let req = MessagesRequestBuilder::new("m", vec![Message::user("hi")], 10)
+            .backoff(ExponentialBackoff::default())
+            .build()
+            .unwrap();
+        assert!(!req.retry_policy.is_disabled());
+        assert!(!req.retry_policy.is_client_default());
     }
 
     #[test]

--- a/anthropic/tests/client_messages.rs
+++ b/anthropic/tests/client_messages.rs
@@ -180,6 +180,73 @@ async fn messages_retries_429_then_succeeds() {
 }
 
 #[tokio::test]
+async fn messages_no_retries_fails_on_first_429() {
+    let server = MockServer::start().await;
+
+    // With `.no_retries()` the client must give up after the first 429 —
+    // exposing that to the mock server as exactly one request hitting the
+    // rate-limit endpoint.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+            "type": "error",
+            "error": {"type": "rate_limit_error", "message": "slow down"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let request = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 10).no_retries().build().unwrap();
+    let err = client.messages(request).await.unwrap_err();
+    match err {
+        AnthropicError::Api(api) => {
+            assert_eq!(api.error_type, "rate_limit_error");
+        }
+        other => panic!("expected Api(rate_limit_error), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn messages_custom_backoff_bounds_retries() {
+    use anthropic::ExponentialBackoff;
+    use std::time::Duration;
+
+    let server = MockServer::start().await;
+
+    // A tight backoff (`max_elapsed_time = 50ms`, `initial_interval = 10ms`)
+    // lets this test assert that a per-request override short-circuits the
+    // client-wide default (15 minutes). Exactly two 429s — one for the
+    // initial attempt, one retry — are enough to exceed 50ms and stop.
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0").set_body_json(json!({
+            "type": "error",
+            "error": {"type": "rate_limit_error", "message": "slow down"}
+        })))
+        .mount(&server)
+        .await;
+
+    let backoff = ExponentialBackoff {
+        initial_interval: Duration::from_millis(10),
+        max_interval: Duration::from_millis(10),
+        max_elapsed_time: Some(Duration::from_millis(50)),
+        multiplier: 1.0,
+        randomization_factor: 0.0,
+        ..ExponentialBackoff::default()
+    };
+
+    let client = build_client(&server);
+    let request =
+        MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 10).backoff(backoff).build().unwrap();
+    let start = std::time::Instant::now();
+    let err = client.messages(request).await.unwrap_err();
+    let elapsed = start.elapsed();
+    assert!(elapsed < Duration::from_secs(2), "custom backoff did not bound retries (elapsed: {elapsed:?})");
+    assert!(matches!(err, AnthropicError::Api(_)));
+}
+
+#[tokio::test]
 async fn messages_preserves_conversation_roundtrip() {
     let server = MockServer::start().await;
 

--- a/anthropic/tests/tracing_integration.rs
+++ b/anthropic/tests/tracing_integration.rs
@@ -1,0 +1,239 @@
+//! Integration tests for the optional `tracing` feature.
+//!
+//! Verify that `execute_bytes` emits a span with the documented fields on the
+//! happy path, and that the span's `attempts` field reflects every retry.
+
+#![cfg(feature = "tracing")]
+
+use std::sync::{Arc, Mutex};
+
+use anthropic::types::{Message, MessagesRequestBuilder};
+use anthropic::Client;
+use serde_json::json;
+use tracing::field::{Field, Visit};
+use tracing::instrument::WithSubscriber;
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Event, Metadata, Subscriber};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Recorded fields for a single span.
+#[derive(Clone, Debug, Default)]
+struct SpanRecord {
+    name: String,
+    method: Option<String>,
+    path: Option<String>,
+    status: Option<u64>,
+    attempts: Option<u64>,
+    duration_ms: Option<u64>,
+}
+
+#[derive(Default, Debug)]
+struct CapturingVisitor {
+    method: Option<String>,
+    path: Option<String>,
+    status: Option<u64>,
+    attempts: Option<u64>,
+    duration_ms: Option<u64>,
+}
+
+impl Visit for CapturingVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        match field.name() {
+            "method" => self.method = Some(format!("{value:?}").trim_matches('"').to_string()),
+            "path" => self.path = Some(format!("{value:?}").trim_matches('"').to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "method" => self.method = Some(value.to_string()),
+            "path" => self.path = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "status" => self.status = Some(value),
+            "attempts" => self.attempts = Some(value),
+            "duration_ms" => self.duration_ms = Some(value),
+            _ => {}
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_u64(field, value as u64);
+    }
+}
+
+/// A minimal subscriber that captures `anthropic.http` span fields into a
+/// shared vector. We only care about two properties for the tests: (1) the
+/// span is emitted for every call, and (2) the `attempts` field records the
+/// real retry count.
+#[derive(Clone)]
+struct CapturingSubscriber {
+    spans: Arc<Mutex<Vec<SpanRecord>>>,
+    next_id: Arc<std::sync::atomic::AtomicU64>,
+    active: Arc<Mutex<std::collections::HashMap<u64, SpanRecord>>>,
+}
+
+impl CapturingSubscriber {
+    fn new() -> (Self, Arc<Mutex<Vec<SpanRecord>>>) {
+        let spans = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                spans: spans.clone(),
+                next_id: Arc::new(std::sync::atomic::AtomicU64::new(1)),
+                active: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            },
+            spans,
+        )
+    }
+}
+
+impl Subscriber for CapturingSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, span: &Attributes<'_>) -> Id {
+        let id = self.next_id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let mut visitor = CapturingVisitor::default();
+        span.record(&mut visitor);
+        let record = SpanRecord {
+            name: span.metadata().name().to_string(),
+            method: visitor.method,
+            path: visitor.path,
+            status: visitor.status,
+            attempts: visitor.attempts,
+            duration_ms: visitor.duration_ms,
+        };
+        self.active.lock().unwrap().insert(id, record);
+        Id::from_u64(id)
+    }
+
+    fn record(&self, span: &Id, values: &Record<'_>) {
+        let mut visitor = CapturingVisitor::default();
+        values.record(&mut visitor);
+        if let Some(record) = self.active.lock().unwrap().get_mut(&span.into_u64()) {
+            if let Some(v) = visitor.method {
+                record.method = Some(v);
+            }
+            if let Some(v) = visitor.path {
+                record.path = Some(v);
+            }
+            if let Some(v) = visitor.status {
+                record.status = Some(v);
+            }
+            if let Some(v) = visitor.attempts {
+                record.attempts = Some(v);
+            }
+            if let Some(v) = visitor.duration_ms {
+                record.duration_ms = Some(v);
+            }
+        }
+    }
+
+    fn record_follows_from(&self, _: &Id, _: &Id) {}
+    fn event(&self, _: &Event<'_>) {}
+    fn enter(&self, _: &Id) {}
+    fn exit(&self, _: &Id) {}
+
+    fn try_close(&self, id: Id) -> bool {
+        if let Some(record) = self.active.lock().unwrap().remove(&id.into_u64()) {
+            if record.name == "anthropic.http" {
+                self.spans.lock().unwrap().push(record);
+            }
+        }
+        true
+    }
+}
+
+fn build_client(server: &MockServer) -> Client {
+    Client::builder().api_key("test-key").api_base(server.uri()).build().expect("client")
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "msg_ok",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "ok"}],
+        "model": "claude",
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {"input_tokens": 1, "output_tokens": 1}
+    })
+}
+
+#[tokio::test]
+async fn tracing_records_span_fields_on_success() {
+    let (subscriber, spans) = CapturingSubscriber::new();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let request = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 10).no_retries().build().unwrap();
+
+    let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+    async {
+        client.messages(request).await.expect("ok");
+    }
+    .with_subscriber(dispatch)
+    .await;
+
+    let collected = spans.lock().unwrap().clone();
+    let http_spans: Vec<_> = collected.iter().filter(|s| s.name == "anthropic.http").collect();
+    assert!(!http_spans.is_empty(), "expected at least one anthropic.http span");
+    let span = http_spans[0];
+    assert_eq!(span.method.as_deref(), Some("POST"), "method field missing");
+    assert_eq!(span.path.as_deref(), Some("/v1/messages"), "path field missing");
+    assert_eq!(span.attempts, Some(1));
+    assert!(span.duration_ms.is_some(), "duration_ms must be recorded");
+}
+
+#[tokio::test]
+async fn tracing_records_attempt_count_on_retries() {
+    let (subscriber, spans) = CapturingSubscriber::new();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0").set_body_json(json!({
+            "type": "error",
+            "error": {"type": "rate_limit_error", "message": "slow down"}
+        })))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server);
+    let request = MessagesRequestBuilder::new("claude", vec![Message::user("hi")], 10).build().unwrap();
+    let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+    async {
+        client.messages(request).await.expect("ok");
+    }
+    .with_subscriber(dispatch)
+    .await;
+
+    let collected = spans.lock().unwrap().clone();
+    let http_spans: Vec<_> = collected.iter().filter(|s| s.name == "anthropic.http").collect();
+    assert!(!http_spans.is_empty(), "expected at least one anthropic.http span");
+    // Three attempts: two 429s + one success.
+    assert_eq!(http_spans[0].attempts, Some(3));
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,65 @@
+# cargo-deny configuration.
+#
+# `cargo deny check` enforces advisory, license, and ban policies across the
+# full dependency tree. This file tracks what we consider a policy violation
+# and is checked in CI on every PR — see `.github/workflows/supply-chain.yml`.
+#
+# Keep the bar tight by default; grant an exception only with an inline
+# comment explaining *why* the exception is temporary and what would make it
+# removable.
+
+[graph]
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+]
+all-features = true
+
+[advisories]
+# Any unpatched vulnerability fails CI. `yanked = "warn"` rather than "deny"
+# lets a yanked transitive dependency be reported without instantly blocking
+# merges — use `ignore` below to silence a known yank only after a fix PR is
+# in flight.
+version = 2
+yanked = "warn"
+ignore = []
+
+[licenses]
+# Allowlist-only. Anything not on this list forces a manual review via a
+# license exception (see `exceptions` below).
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "MPL-2.0",
+    "MIT-0",
+    "BSL-1.0",
+]
+confidence-threshold = 0.92
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+# Deny a known-insecure or abandoned package by name here as soon as you
+# learn about it. Empty by default.
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "anthropic-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+# `cargo fuzz` expects the fuzz crate to live outside the primary workspace
+# so that a top-level `cargo test` / `cargo build` does not try to resolve
+# the libfuzzer-sys dependency (which requires nightly). Running fuzz
+# targets is therefore done explicitly via `cargo +nightly fuzz run <name>`
+# from the `fuzz/` directory.
+[package.metadata]
+cargo-fuzz = true
+
+[workspace]
+# Do not inherit from the top-level workspace — this crate is intentionally
+# excluded so `cargo test` at the repo root never tries to resolve nightly
+# fuzz dependencies.
+
+[dependencies]
+# `libfuzzer-sys` provides the sanitizer-aware fuzz entry point and the
+# `fuzz_target!` macro. Version is pinned conservatively — bumping it is
+# fine, but do so deliberately so a transitive sanitizer change is easy to
+# bisect.
+libfuzzer-sys = "0.4"
+anthropic = { path = "../anthropic", default-features = false, features = ["rustls"] }
+
+# Every target is declared here so `cargo fuzz list` discovers it without
+# any additional configuration. `test = false` and `doc = false` keep the
+# targets out of the regular `cargo test` / `cargo doc` run when the fuzz
+# crate is built directly.
+[[bin]]
+name = "parse_error"
+path = "fuzz_targets/parse_error.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_results_jsonl"
+path = "fuzz_targets/parse_results_jsonl.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,49 @@
+# `anthropic-fuzz`
+
+`cargo fuzz` harnesses for the two parsers in this crate that run on
+untrusted bytes pulled off the network:
+
+- `parse_error` — decodes the body of a non-success HTTP response.
+- `parse_results_jsonl` — decodes the JSON-Lines payload returned by the
+  Message Batches results endpoint.
+
+Both parsers are called from the transport critical path in
+`anthropic::client::execute_bytes` and therefore have a hard contract that
+they never panic on arbitrary input. The targets here enforce that
+contract.
+
+## Running locally
+
+`cargo fuzz` requires nightly Rust. From the repository root:
+
+```bash
+cd fuzz
+cargo +nightly fuzz run parse_error
+cargo +nightly fuzz run parse_results_jsonl
+```
+
+List available targets:
+
+```bash
+cargo +nightly fuzz list
+```
+
+Minimize a crash input:
+
+```bash
+cargo +nightly fuzz tmin parse_error path/to/crash
+```
+
+## CI
+
+A short fuzz smoke test runs on the `Fuzz` GitHub Actions workflow (see
+`.github/workflows/fuzz.yml`). It builds every target and runs each for a
+few seconds to catch regressions that cause immediate panics — it is not
+a substitute for a sustained fuzzing campaign on dedicated hardware.
+
+## Layout
+
+This sub-crate is **intentionally excluded** from the top-level Cargo
+workspace so that a plain `cargo test` at the repo root never tries to
+resolve `libfuzzer-sys` (which requires nightly). Run every command
+above from inside `fuzz/`.

--- a/fuzz/fuzz_targets/parse_error.rs
+++ b/fuzz/fuzz_targets/parse_error.rs
@@ -1,0 +1,32 @@
+//! Fuzz target for `anthropic::__fuzz::parse_error`.
+//!
+//! `parse_error` runs on the raw response body of any non-success HTTP
+//! reply the client receives. That body is attacker-controllable — any
+//! middlebox, proxy, or compromised upstream can shape it — so the parser
+//! must:
+//!
+//! 1. Never panic, regardless of input bytes.
+//! 2. Always return an `AnthropicError` (either a parsed `Api` payload or
+//!    an `UnexpectedResponse` fallback).
+//!
+//! The fuzz input is structured as `[status_byte_hi, status_byte_lo, ...body]`
+//! so the harness also exercises every possible HTTP status code. Short
+//! inputs default to status 0 so that `cargo fuzz tmin` does not have to
+//! carry two bytes before it can reach the parser.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let (status, body): (u16, &[u8]) = match data {
+        [a, b, rest @ ..] => (u16::from_be_bytes([*a, *b]), rest),
+        _ => (0, data),
+    };
+
+    // Calling the real entry point — a panic here is an immediate fuzz
+    // finding. We intentionally `drop` the result: the contract is "never
+    // panic, always return an error"; we do not assert on which variant
+    // appears because both are valid.
+    let _ = anthropic::__fuzz::parse_error(status, body);
+});

--- a/fuzz/fuzz_targets/parse_results_jsonl.rs
+++ b/fuzz/fuzz_targets/parse_results_jsonl.rs
@@ -1,0 +1,22 @@
+//! Fuzz target for `anthropic::__fuzz::parse_results_jsonl`.
+//!
+//! `parse_results_jsonl` runs on the JSON-Lines results file downloaded
+//! from `GET /v1/messages/batches/{id}/results`. The body is tens-of-MB
+//! of line-delimited JSON, is never pre-validated, and (like `parse_error`)
+//! could be tampered with by an adversarial proxy. The parser's contract is:
+//!
+//! 1. Never panic.
+//! 2. Either return a `Vec<BatchResultItem>` of successfully-parsed lines
+//!    or an `AnthropicError::InvalidRequest` naming the first bad line.
+//!
+//! The harness feeds raw bytes directly: the `__fuzz` wrapper handles
+//! lossy UTF-8 conversion to mirror what the transport layer does on a
+//! real response body.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = anthropic::__fuzz::parse_results_jsonl(data);
+});


### PR DESCRIPTION
- tracing: new optional Cargo feature that wraps every HTTP call on the
  transport critical path in an `anthropic.http` span carrying `method`,
  `path`, `status`, `attempts`, and `duration_ms`, plus per-attempt debug
  events. Compiles out entirely when the feature is off.
- retry override: new `RetryPolicy` type plus
  `MessagesRequestBuilder::backoff` / `no_retries` / `retry_policy` (and
  equivalents on `CountTokensRequestBuilder` / `CreateBatchRequest`) so
  interactive paths can opt out of retries and background workers can
  stretch them — without rebuilding the client.
- MSRV: pin `package.rust-version = "1.82"` in `anthropic/Cargo.toml` and
  add a dedicated MSRV job to `.github/workflows/ci.yml` that reads the
  version from `Cargo.toml` and builds + tests on the declared toolchain.
- supply chain: new `.github/workflows/supply-chain.yml` that runs
  `cargo audit` (RustSec advisory DB) and `cargo deny` on every PR, push,
  and daily cron. Policy lives in a committed `deny.toml` with an
  allowlist-only licence set and deny-on-unknown source policy.
- fuzzing: new `fuzz/` sub-crate (excluded from the primary workspace so
  stable builds never pull libfuzzer-sys) with `cargo-fuzz` harnesses for
  `parse_error` and `parse_results_jsonl`. Both parsers run on untrusted
  bytes from the network and have a "never panic" contract that the fuzz
  targets enforce. A small regression corpus is baked into the library
  test suite via a hidden `__fuzz` module so the same invariants are
  checked in regular CI. A dedicated `Fuzz` GitHub Actions workflow
  smoke-runs each target for 30 seconds on nightly.

All existing tests plus the new tracing and retry integration tests
pass under both the default and full-feature configurations.

https://claude.ai/code/session_01LBCuatiRTCtBWdoo1BNoQD